### PR TITLE
fix: test if Sentry is loaded

### DIFF
--- a/public/vocables/index.html
+++ b/public/vocables/index.html
@@ -197,10 +197,13 @@
 
             $(function () {
                 MainController.initConfig(function (err) {
-
                     // sentry/glitchtip
-                    if (Config.sentryDsnJsFront && typeof Sentry == 'object') {
-                        Sentry.init({ dsn: Config.sentryDsnJsFront });
+                    if (Config.sentryDsnJsFront) {
+                        if (typeof Sentry == "object") {
+                            Sentry.init({ dsn: Config.sentryDsnJsFront });
+                        } else {
+                            console.warn("Sentry DSN found in config, but library could not be loaded and initialized.");
+                        }
                     }
 
                     authentication.init();

--- a/public/vocables/index.html
+++ b/public/vocables/index.html
@@ -197,8 +197,9 @@
 
             $(function () {
                 MainController.initConfig(function (err) {
+
                     // sentry/glitchtip
-                    if (Config.sentryDsnJsFront) {
+                    if (Config.sentryDsnJsFront && typeof Sentry == 'object') {
                         Sentry.init({ dsn: Config.sentryDsnJsFront });
                     }
 


### PR DESCRIPTION
Test if Sentry is defined to avoid errors when an adblocker is used