### PR TITLE
chore: removes unused route in slsv

### DIFF
--- a/legacy_routes.js
+++ b/legacy_routes.js
@@ -87,12 +87,6 @@ router.post(serverParams.routesRootUrl + "/slsv", ensureLoggedIn(), function (re
             processResponse(response, err, result);
         });
     }
-    // XXX refactor to GET api/v1/paths/readCsv
-    if (req.body.readCsv) {
-        DataController.readCsv(req.body.dir, req.body.fileName, JSON.parse(req.body.options), function (err, result) {
-            processResponse(response, err, result);
-        });
-    }
     // XXX refactor to GET api/v1/paths/createTriplesFromCsv
     if (req.body.createTriplesFromCsv) {
         CsvTripleBuilder.createTriplesFromCsv(req.body.dir, req.body.fileName, JSON.parse(req.body.options), function (err, result) {


### PR DESCRIPTION
Claude created the new route at api/v1/data/csv. This PR only removes the legacy route.