### PR TITLE
ci(mirror): push to gitlab

### DIFF
--- a/.github/workflows/git-push.yml
+++ b/.github/workflows/git-push.yml
@@ -1,0 +1,20 @@
+name: Mirror to GitLab
+on: push
+
+
+jobs:
+  build:
+    environment: GitLab config
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: push
+        run: |
+          export GIT_SSH_COMMAND='ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'
+          gitlab_repo_url_with_credentials="https://token:${{ secrets.GITLAB_ACCESS_TOKEN }}@${{ secrets.GITLAB_REPO }}"
+          git remote add gitlab "$gitlab_repo_url_with_credentials"
+          branch_name=$(echo $GITHUB_REF | sed 's/refs\/heads\///')
+          git push gitlab "$branch_name" --force
+          git push gitlab --tags --force

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,6 @@
+include:
+  - project: "open-source/gitlab-ci-templates"
+    ref: "branch/v2"
+    file:
+      - "templates/base.yml"
+      - "templates/no-duplicated-ci-pipelines.yml"


### PR DESCRIPTION
Add a job that sync this repo to a GitLab instance. Useful to use GitLab CI