### PR TITLE
Update README.md with links to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ A key feature of SLSV is graph visualization and interaction performed using exc
 Annotate tool allows annotate textual corpus with several registered lexical resources
 and identify missing terms
 
+## Documentation
+
+Please visit [Technical Design Documents](http://souslesens.org/index.php/documentation) for details on the technical details of souslesensVocable.
+
+Please watch the videos at [videos sections](http://souslesens.org/index.php/videos/) for getting started with souslesensVocable.
+
+[SLSV Glossary](http://souslesens.org/index.php/slsv-glossary/) provides definitions of several terms used in souslesensVocable.
+
 ## Deploy a production instance
 
 ### Prerequisites


### PR DESCRIPTION
For addressing the following comment of ESWC paper reviewer: "6) The site offers in-depth documentation providing both textual technical documentation (http://souslesens.org/index.php/documentation/) and videos of use (http://souslesens.org/index.php/videos/). I found the documentation on the website starting from the paper but could not reach it from the GitHub repository (https://github.com/souslesens/souslesensVocables). However, currently, the documentation on the site has a much higher level of detail than that on GitHub. I therefore suggest adding a reference to the site documentation to the repository.

7) More generally, the toolkit has minimum documentation on GitHub. Is there any plan to improve on that? "