### PR TITLE
fix: prevent infinite rendering by moving state update outside of render flow

### DIFF
--- a/mainapp/src/Component/SourcesTable.tsx
+++ b/mainapp/src/Component/SourcesTable.tsx
@@ -350,9 +350,12 @@ const SourceForm = ({ source = defaultSource(ulid()), create = false, me = "" }:
 
     const _handleFieldUpdate = (event: React.ChangeEvent<HTMLInputElement>) => update({ type: Type.UserAddedGraphUri, payload: event.target.value });
 
-    if (sourceModel.sourceForm.owner.length == 0) {
-        update({ type: Type.UserUpdatedField, payload: { fieldname: "owner", newValue: me } });
-    }
+    React.useEffect(() => {
+        if (sourceModel.sourceForm.owner.length == 0 && me !== "") {
+            update({ type: Type.UserUpdatedField, payload: { fieldname: "owner", newValue: me } });
+        }
+    }, [sourceModel.sourceForm.owner]
+    )
 
     const handleSparql_serverUpdate = (fieldName: string) => (event: React.ChangeEvent<HTMLTextAreaElement>) => {
         update({


### PR DESCRIPTION
Updating the state of the component is a side effect and a side effect shouldn't be triggered from within render flow.
Also, I don't know why the `me` variable can be empty, which was leading to the condition being always true.