### PR TITLE
fix(mainapp/configeditor): do not validate own source prefix in edit mode

### DIFF
--- a/mainapp/src/Component/SourcesDialog.tsx
+++ b/mainapp/src/Component/SourcesDialog.tsx
@@ -89,11 +89,13 @@ export const SourcesDialog = ({ edit, me, onClose, onSubmit, open, selectedSourc
                 });
             }
             if (sourcesPrefixes.includes(value.prefix)) {
-                context.addIssue({
-                    code: z.ZodIssueCode.custom,
-                    message: "This prefix is already used by another source",
-                    path: ["prefix"],
-                });
+                if (!edit || value.prefix !== source.prefix) {
+                    context.addIssue({
+                        code: z.ZodIssueCode.custom,
+                        message: "This prefix is already used by another source",
+                        path: ["prefix"],
+                    });
+                }
             }
             if (value.group.trim().length < 3) {
                 context.addIssue({


### PR DESCRIPTION
Avoid to check if the current source prefix was already in the available
prefixes, since this is the case.
