### PR TITLE
chore(docker): update elasticsearch to version 7.17.26

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -60,7 +60,7 @@ services:
             - dev-backend
 
     elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:7.17.4
+        image: docker.elastic.co/elasticsearch/elasticsearch:7.17.26
         ports:
             - 9200:9200
         environment:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -68,7 +68,7 @@ services:
             - backend
 
     elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:7.17.4
+        image: docker.elastic.co/elasticsearch/elasticsearch:7.17.26
         environment:
             ES_JAVA_OPTS: "-Xmx256m -Xms256m"
             discovery.type: single-node


### PR DESCRIPTION
With the lastest version of elasticsearch, its now possible to run the
container with the Linux kernel 6.12.
