### PR TITLE
fix(mainapp): correctly select the group in edit mode with the Source editor

### DIFF
--- a/mainapp/src/Component/SourcesDialog.tsx
+++ b/mainapp/src/Component/SourcesDialog.tsx
@@ -235,8 +235,6 @@ export const SourcesDialog = ({ edit, me, onClose, onSubmit, open, selectedSourc
                         value={source.prefix}
                     />
                     <Autocomplete
-                        autoSelect
-                        disableCloseOnSelect
                         freeSolo
                         id="group"
                         onChange={(_e, value) => handleField("group", value)}


### PR DESCRIPTION
The autoSelect prop on the Autocomplete component was messing with the group
selection, since the focused item was selected (even with a click outside the
contextual menu).

The disableCloseOnSelect is useless in this case, since there is no multiple
selection.

Related to #1049
