### PR TITLE
fix(mainapp): avoid to raise a ZodError when starting the application

### DIFF
--- a/mainapp/src/Source.ts
+++ b/mainapp/src/Source.ts
@@ -188,7 +188,7 @@ export const ServerSourceSchema = z.object({
     published: z.boolean().default(false),
     imports: z.array(z.string()).default([]),
     taxonomyPredicates: z.array(z.string()).default(["rdfs:subClassOf"]),
-    accessControl: z.string(),
+    accessControl: z.string().default(""),
 });
 
 const InputSourceSchemaBase = {


### PR DESCRIPTION
The defaultSource object is built from the zod object, but the accessControl is
not defined by default, causing the ZodError to be raised during the starting
process.

Using the default value will allow to bypass this exception.
