### PR TITLE
fix(mainapp): always manage the value of the groups field in the sources editor

### DIFF
--- a/mainapp/src/Component/SourcesDialog.tsx
+++ b/mainapp/src/Component/SourcesDialog.tsx
@@ -238,6 +238,7 @@ export const SourcesDialog = ({ edit, me, onClose, onSubmit, open, selectedSourc
                         freeSolo
                         id="group"
                         onChange={(_e, value) => handleField("group", value)}
+                        onInputChange={(_e, value) => handleField("group", value)}
                         options={groups}
                         renderInput={(params) => <TextField error={errors.group !== undefined} helperText={errors.group} {...params} label="Group" required />}
                         value={source.group}


### PR DESCRIPTION
The `onChange` property is only used when the user press the Enter key, but
since this widget use the freeSolo mode, we need to also use the `onInputChange`
property.
