### PR TITLE
fix(mainapp): correctly sort the date in the Logs table view

### DIFF
--- a/mainapp/src/Component/LogsTable.tsx
+++ b/mainapp/src/Component/LogsTable.tsx
@@ -93,9 +93,6 @@ function LogsTableComponent({ logFiles }: { logFiles: LogFiles }) {
             .sort((a: Log, b: Log) => {
                 const left: string = a[orderBy];
                 const right: string = b[orderBy];
-                if (orderBy === "timestamp") {
-                    return order === "asc" ? Number(new Date(left).getTime() > new Date(right).getTime()) : Number(new Date(left) < new Date(right));
-                }
                 return order === "asc" ? left.localeCompare(right) : right.localeCompare(left);
             });
     }, [order, orderBy, selectedLogs]);


### PR DESCRIPTION
This date use the format `YYYY-MM-DD HH:MM:SS`, so the sort process can be done directly from the string, instead of trying to cast the value as Date.
