### PR TITLE
Fix: MappingModeler : Journal d'erreur et de log sur les triplets qui ont marché.

### DIFF
--- a/api/v1/paths/kg/mappings/recreateTriples.js
+++ b/api/v1/paths/kg/mappings/recreateTriples.js
@@ -36,6 +36,7 @@ export default function () {
                 tables: out.table,
                 deleteResult: out.deleteResult,
                 result: out.result,
+                report: out.result && out.result.report,
                 mode: out.mode,
                 tablesProcessed: out.tablesProcessed,
             });

--- a/bin/KGbuilder/KGbuilder_main.js
+++ b/bin/KGbuilder/KGbuilder_main.js
@@ -84,6 +84,7 @@ var KGbuilder_main = {
             tableProcessingParams.uniqueTriplesMap = {};
             var sampleTriples = [];
             var totalTriplesCount = {};
+            var totalReport = {};
 
             /**
              * for each table get columnsMappingMap and create tripels
@@ -210,6 +211,9 @@ var KGbuilder_main = {
                                     } else {
                                         if (!totalTriplesCount[table]) totalTriplesCount[table] = 0;
                                         totalTriplesCount[table] += result.totalTriplesCount;
+                                        if (result.report) {
+                                            totalReport[table] = result.report;
+                                        }
                                     }
                                     callbackSeries();
                                 });
@@ -223,7 +227,7 @@ var KGbuilder_main = {
                 },
 
                 function (err) {
-                    return callback(err, { sampleTriples: sampleTriples, totalTriplesCount: totalTriplesCount });
+                    return callback(err, { sampleTriples: sampleTriples, totalTriplesCount: totalTriplesCount, report: options.sampleSize ? undefined : totalReport });
                 },
             );
 

--- a/bin/KGbuilder/triplesMaker.js
+++ b/bin/KGbuilder/triplesMaker.js
@@ -33,6 +33,9 @@ var TriplesMaker = {
         tableProcessingParams.randomIdentiersMap = {}; // identifiers with scope the whole table
         tableProcessingParams.blankNodesMap = {}; // identifiers with scope the whole table
         tableProcessingParams.isSampleData = options.sampleSize;
+        tableProcessingParams.report = options.sampleSize
+            ? null
+            : { table: tableInfos.table, skippedMappings: [], errors: [], skippedMappingsTruncated: false, errorsTruncated: false };
 
         var message = {
             table: tableInfos.table,
@@ -130,7 +133,7 @@ var TriplesMaker = {
                         KGbuilder_socket.message(options.clientSocketId, message);
                         // KGbuilder_socket.message(options.clientSocketId, " DONE " + processedRecords + "records  from " + tableInfos.table + " : " + (totalTriplesCount) + " triples", false);
 
-                        return callback(err, { sampleTriples: sampleTriples, totalTriplesCount: totalTriplesCount });
+                        return callback(err, { sampleTriples: sampleTriples, totalTriplesCount: totalTriplesCount, report: tableProcessingParams.report });
                     },
                 );
             });
@@ -275,14 +278,51 @@ var TriplesMaker = {
             message.operation = "finished";
             message.totalTriples = totalTriplesCount;
             KGbuilder_socket.message(options.clientSocketId, message);
-            return callback(null, { sampleTriples: sampleTriples, totalTriplesCount: totalTriplesCount });
+            return callback(null, { sampleTriples: sampleTriples, totalTriplesCount: totalTriplesCount, report: tableProcessingParams.report });
         }
     },
 
     buildTriples: function (data, tableProcessingParams, options, callback) {
         var columnMappings = tableProcessingParams.tableColumnsMappings;
+        var report = tableProcessingParams.report || null;
+        var tableName = tableProcessingParams.tableInfos && tableProcessingParams.tableInfos.table;
+        var MAX_REPORT = 500;
 
         var batchTriples = [];
+
+        var reportRowIndex = 0;
+        var reportColumnId = null;
+        var reportPredicate = null;
+
+        function addReportSkip(reason, rawValue) {
+            if (!report || report.skippedMappings.length >= MAX_REPORT) {
+                if (report && !report.skippedMappingsTruncated) report.skippedMappingsTruncated = true;
+                return;
+            }
+            report.skippedMappings.push({
+                table: tableName,
+                rowIndex: reportRowIndex,
+                columnId: reportColumnId,
+                predicate: reportPredicate,
+                reason: reason,
+                rawValue: rawValue !== undefined ? rawValue : null,
+            });
+        }
+
+        function addReportError(error, rawValue) {
+            if (!report || report.errors.length >= MAX_REPORT) {
+                if (report && !report.errorsTruncated) report.errorsTruncated = true;
+                return;
+            }
+            report.errors.push({
+                table: tableName,
+                rowIndex: reportRowIndex,
+                columnId: reportColumnId,
+                predicate: reportPredicate,
+                error: error && error.message ? error.message : String(error),
+                rawValue: rawValue !== undefined ? rawValue : null,
+            });
+        }
 
         function addTriple(subjectUri, predicateUri, objectUri) {
             if (subjectUri && predicateUri && objectUri) {
@@ -294,6 +334,9 @@ var TriplesMaker = {
                     tableProcessingParams.uniqueTriplesMap[triplelHashCode] = 1;
                     batchTriples.push(triple);
                 }
+            } else if (subjectUri || predicateUri || objectUri) {
+                var reason = !objectUri ? "null_object" : !subjectUri ? "null_subject" : "null_predicate";
+                addReportSkip(reason, null);
             }
         }
 
@@ -306,6 +349,7 @@ var TriplesMaker = {
 
             var lineColumnUrisMap = {};
             var rowIndex = index + options.currentBatchRowIndex;
+            reportRowIndex = rowIndex;
             var blankNodesMap = {};
             for (var key in line) {
                 if (line[key]) {
@@ -318,6 +362,8 @@ var TriplesMaker = {
             }
 
             for (var columnId in columnMappings) {
+                reportColumnId = columnId;
+                reportPredicate = null;
                 // filter columns
                 if (options.filterMappingIds && options.filterMappingIds.indexOf(columnId) < 0) {
                     continue;
@@ -331,6 +377,7 @@ var TriplesMaker = {
                     }
                 }
                 if (!columnUri) {
+                    addReportSkip("null_column_uri", line[columnMappings[columnId] && columnMappings[columnId].id] || null);
                     continue;
                 }
 
@@ -342,6 +389,7 @@ var TriplesMaker = {
                     if (!columnId) {
                         return;
                     }
+                    reportPredicate = mapping.p;
 
                     var object = null;
                     // if no matching item for mapping.o  and no fixed uri return
@@ -359,6 +407,7 @@ var TriplesMaker = {
                         } else {
                             object = TriplesMaker.getColumnUri(line, mapping.objColId, columnMappings, rowIndex, tableProcessingParams);
                             if (!object) {
+                                addReportSkip("null_object_column_uri", line[mapping.o] || null);
                                 return;
                             }
                         }
@@ -367,7 +416,12 @@ var TriplesMaker = {
                         object = TriplesMaker.getColumnUri(line, mapping.objColId, columnMappings, rowIndex, tableProcessingParams);
                     } else if (mapping.transform) {
                         var objStr = line[mapping.o];
-                        object = tableProcessingParams.jsFunctionsMap[mapping.s](objStr, "o", mapping.p, line, mapping);
+                        try {
+                            object = tableProcessingParams.jsFunctionsMap[mapping.s](objStr, "o", mapping.p, line, mapping);
+                        } catch (transformErr) {
+                            addReportError(transformErr, objStr);
+                            return;
+                        }
                     } else if (mapping.isString) {
                         var objStr = line[mapping.o];
                         object = '"' + util.formatStringForTriple(objStr) + '"';
@@ -388,7 +442,9 @@ var TriplesMaker = {
             }
             // process columnToColumnMappings
             for (var edgeId in tableProcessingParams.columnToColumnEdgesMap) {
+                reportColumnId = edgeId;
                 var edge = tableProcessingParams.columnToColumnEdgesMap[edgeId];
+                reportPredicate = edge.data && edge.data.id;
                 var subjectUri = TriplesMaker.getColumnUri(line, edge.from, columnMappings, rowIndex, tableProcessingParams);
                 var objectUri = TriplesMaker.getColumnUri(line, edge.to, columnMappings, rowIndex, tableProcessingParams);
                 var property = TriplesMaker.getPropertyUri(edge.data.id);
@@ -405,11 +461,13 @@ var TriplesMaker = {
 
             // isolated predicates (dont want to duplicate label, type...
             for (var columnId in columnMappings) {
+                reportColumnId = columnId;
                 // filter columns
                 var otherPredicates = columnMappings[columnId].otherPredicates;
                 if (otherPredicates) {
                     otherPredicates.forEach(function (item) {
                         if (options.filterMappingIds && options.filterMappingIds.indexOf(item.property) > -1) {
+                            reportPredicate = item.property;
                             var subjectUri = TriplesMaker.getColumnUri(line, columnId, columnMappings, rowIndex, tableProcessingParams);
                             var object = TriplesMaker.getFormatedLiteral(line, {
                                 dataType: item.range,
@@ -441,6 +499,7 @@ var TriplesMaker = {
                         return filteredBasicProperties.indexOf(mapping.p) > -1;
                     });
                     filteredMappings.forEach(function (mapping) {
+                        reportPredicate = mapping.p;
                         var subjectUri = TriplesMaker.getColumnUri(line, columnId, columnMappings, rowIndex, tableProcessingParams);
                         var object = null;
                         var property = TriplesMaker.getPropertyUri(mapping.p);
@@ -454,6 +513,7 @@ var TriplesMaker = {
                             } else {
                                 object = TriplesMaker.getColumnUri(line, mapping.objColId, columnMappings, rowIndex, tableProcessingParams);
                                 if (!object) {
+                                    addReportSkip("null_object_column_uri", null);
                                     return;
                                 }
                             }
@@ -465,6 +525,7 @@ var TriplesMaker = {
                             object = TriplesMaker.getColumnUri(line, mapping.objColId, columnMappings, rowIndex, tableProcessingParams);
                         }
                         if (!object || !property || !subjectUri) {
+                            addReportSkip("null_triple_component", null);
                             return;
                         }
                         addTriple(subjectUri, property, object);

--- a/public/vocables/modules/tools/mappingModeler/tripleFactory.js
+++ b/public/vocables/modules/tools/mappingModeler/tripleFactory.js
@@ -325,6 +325,7 @@ var TripleFactory = (function () {
                         progressBar.style.display = "none";
                     }
                 } else {
+                    downloadReport(result && result.report, DataSourceManager.currentSlsvSource, table);
                     if (options.deleteTriples) {
                         $("#KGcreator_infosDiv").val(result.result);
                         UI.message(result.result, true);
@@ -396,6 +397,8 @@ var TripleFactory = (function () {
             contentType: "application/json; charset=utf-8",
             dataType: "json",
             success: function (data) {
+                var report = (data && data.report) || (data && data.result && data.result.report);
+                downloadReport(report, data && data.source, data && data.tablesProcessed);
                 if (onSuccess) onSuccess(data);
             },
             error: function (xhr) {
@@ -1001,6 +1004,88 @@ var TripleFactory = (function () {
     /* self.showFilterMappingsDialog=function(){
         TripleFactory.initFilterMappingDialog()
     }*/
+
+    function downloadReport(report, source, tables) {
+        if (!report) return;
+        var hasErrors = report.errors && report.errors.length > 0;
+        var hasSkipped = report.skippedMappings && report.skippedMappings.length > 0;
+
+        if (!hasErrors) {
+            var tableKeys = Object.keys(report);
+            tableKeys.forEach(function (t) {
+                var tableReport = report[t];
+                if (tableReport && tableReport.errors && tableReport.errors.length > 0) hasErrors = true;
+                if (tableReport && tableReport.skippedMappings && tableReport.skippedMappings.length > 0) hasSkipped = true;
+            });
+        }
+
+        if (!hasErrors && !hasSkipped) return;
+
+        var lines = [];
+        lines.push("=== Triple Generation Report ===");
+        lines.push("Date: " + new Date().toISOString());
+        lines.push("Source: " + (source || "unknown"));
+        if (tables) {
+            lines.push("Tables: " + (Array.isArray(tables) ? tables.join(", ") : String(tables)));
+        }
+        lines.push("");
+
+        function formatTableReport(tableReport) {
+            var tableLines = [];
+            if (tableReport.errors && tableReport.errors.length > 0) {
+                tableLines.push("--- Errors (" + tableReport.errors.length + (tableReport.errorsTruncated ? "+" : "") + ") ---");
+                tableReport.errors.forEach(function (e) {
+                    var parts = ["Row " + e.rowIndex];
+                    if (e.columnId) parts.push("Column: " + e.columnId);
+                    if (e.predicate) parts.push("Predicate: " + e.predicate);
+                    parts.push("Error: " + e.error);
+                    if (e.rawValue !== null && e.rawValue !== undefined) parts.push("Value: " + e.rawValue);
+                    tableLines.push("  " + parts.join(", "));
+                });
+                tableLines.push("");
+            }
+            if (tableReport.skippedMappings && tableReport.skippedMappings.length > 0) {
+                tableLines.push("--- Skipped Mappings (" + tableReport.skippedMappings.length + (tableReport.skippedMappingsTruncated ? "+" : "") + ") ---");
+                tableReport.skippedMappings.forEach(function (s) {
+                    var parts = ["Row " + s.rowIndex];
+                    if (s.columnId) parts.push("Column: " + s.columnId);
+                    if (s.predicate) parts.push("Predicate: " + s.predicate);
+                    parts.push("Reason: " + s.reason);
+                    if (s.rawValue !== null && s.rawValue !== undefined) parts.push("Value: " + s.rawValue);
+                    tableLines.push("  " + parts.join(", "));
+                });
+                tableLines.push("");
+            }
+            return tableLines;
+        }
+
+        if (report.errors || report.skippedMappings) {
+            var tl = formatTableReport(report);
+            tl.forEach(function (l) { lines.push(l); });
+        } else {
+            Object.keys(report).forEach(function (tableName) {
+                var tableReport = report[tableName];
+                if (!tableReport) return;
+                var hasTableContent = (tableReport.errors && tableReport.errors.length > 0) || (tableReport.skippedMappings && tableReport.skippedMappings.length > 0);
+                if (!hasTableContent) return;
+                lines.push("=== Table: " + tableName + " ===");
+                var tl = formatTableReport(tableReport);
+                tl.forEach(function (l) { lines.push(l); });
+            });
+        }
+
+        var content = lines.join("\n");
+        var blob = new Blob([content], { type: "text/plain;charset=utf-8" });
+        var url = URL.createObjectURL(blob);
+        var a = document.createElement("a");
+        a.href = url;
+        var dateStr = new Date().toISOString().slice(0, 10);
+        a.download = "triple_report_" + (source || "unknown") + "_" + dateStr + ".txt";
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+    }
 
     return self;
 })();

--- a/tests/triplesMaker.report.test.js
+++ b/tests/triplesMaker.report.test.js
@@ -1,0 +1,139 @@
+import TriplesMaker from "../bin/KGbuilder/triplesMaker.js";
+
+describe("TriplesMaker report", () => {
+    function makeParams(report) {
+        return {
+            tableColumnsMappings: {},
+            columnToColumnEdgesMap: {},
+            uniqueTriplesMap: {},
+            allColumnsMappings: {},
+            jsFunctionsMap: {},
+            sourceInfos: { graphUri: "http://example.org/graph" },
+            tableInfos: { table: "test_table" },
+            isSampleData: false,
+            randomIdentiersMap: {},
+            blankNodesMap: {},
+            report: report,
+        };
+    }
+
+    test("report is null when not provided", (done) => {
+        var params = makeParams(null);
+        TriplesMaker.buildTriples([], params, { currentBatchRowIndex: 0 }, function (err, triples) {
+            expect(err).toBeNull();
+            expect(triples).toEqual([]);
+            done();
+        });
+    });
+
+    test("records skipped mapping when column URI is null", (done) => {
+        var report = { table: "test_table", skippedMappings: [], errors: [], skippedMappingsTruncated: false, errorsTruncated: false };
+        var params = makeParams(report);
+        params.tableColumnsMappings = {
+            colA: {
+                id: "missing_col",
+                type: "Column",
+                uriType: "fromLabel",
+                baseURI: "http://example.org/",
+                mappings: [],
+            },
+        };
+
+        var data = [{ other_col: "value" }];
+        TriplesMaker.buildTriples(data, params, { currentBatchRowIndex: 0 }, function (err, triples) {
+            expect(err).toBeNull();
+            expect(report.skippedMappings.length).toBeGreaterThan(0);
+            expect(report.skippedMappings[0].reason).toBe("null_column_uri");
+            expect(report.skippedMappings[0].rowIndex).toBe(0);
+            done();
+        });
+    });
+
+    test("records error when transform function throws", (done) => {
+        var report = { table: "test_table", skippedMappings: [], errors: [], skippedMappingsTruncated: false, errorsTruncated: false };
+        var params = makeParams(report);
+        params.tableColumnsMappings = {
+            colA: {
+                id: "colA",
+                type: "Column",
+                uriType: "fromLabel",
+                baseURI: "http://example.org/",
+                mappings: [
+                    {
+                        s: "colA",
+                        p: "http://example.org/prop",
+                        o: "colA",
+                        transform: true,
+                    },
+                ],
+            },
+        };
+        params.jsFunctionsMap = {
+            colA: function () {
+                throw new Error("transform error");
+            },
+        };
+
+        var data = [{ colA: "somevalue" }];
+        TriplesMaker.buildTriples(data, params, { currentBatchRowIndex: 0 }, function (err, triples) {
+            expect(err).toBeNull();
+            expect(report.errors.length).toBe(1);
+            expect(report.errors[0].error).toContain("transform error");
+            expect(report.errors[0].rowIndex).toBe(0);
+            done();
+        });
+    });
+
+    test("no report entries on success", (done) => {
+        var report = { table: "test_table", skippedMappings: [], errors: [], skippedMappingsTruncated: false, errorsTruncated: false };
+        var params = makeParams(report);
+        params.tableColumnsMappings = {
+            colA: {
+                id: "colA",
+                type: "Column",
+                uriType: "fromLabel",
+                baseURI: "http://example.org/",
+                mappings: [
+                    {
+                        s: "colA",
+                        p: "http://example.org/prop",
+                        o: "colA",
+                        isString: true,
+                    },
+                ],
+            },
+        };
+
+        var data = [{ colA: "hello" }];
+        TriplesMaker.buildTriples(data, params, { currentBatchRowIndex: 0 }, function (err, triples) {
+            expect(err).toBeNull();
+            expect(triples.length).toBeGreaterThan(0);
+            expect(report.errors.length).toBe(0);
+            done();
+        });
+    });
+
+    test("skippedMappingsTruncated flag set when over MAX_REPORT", (done) => {
+        var report = { table: "test_table", skippedMappings: [], errors: [], skippedMappingsTruncated: false, errorsTruncated: false };
+        var params = makeParams(report);
+        params.tableColumnsMappings = {
+            colA: {
+                id: "missing_col",
+                type: "Column",
+                uriType: "fromLabel",
+                baseURI: "http://example.org/",
+                mappings: [],
+            },
+        };
+
+        var data = new Array(600).fill(null).map(function (_, i) {
+            return { other: "v" + i };
+        });
+        TriplesMaker.buildTriples(data, params, { currentBatchRowIndex: 0 }, function (err, triples) {
+            expect(err).toBeNull();
+            expect(report.skippedMappings.length).toBe(500);
+            expect(report.skippedMappingsTruncated).toBe(true);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
Closes #1872

## What was done

- **`bin/KGbuilder/triplesMaker.js`**: Added an in-memory `report` object (initialized per table in `readAndProcessData`) that tracks skipped mappings and errors during triple generation. Key tracking points:
  - `null_column_uri`: when a column's source value is null and no URI can be built
  - `null_object_column_uri`: when an explicit skip happens before `addTriple` (source column has no value and no fallback)
  - `null_triple_component`: when a triple component is null in filtered predicates
  - `null_object` / `null_subject`: caught in the modified `addTriple` when any component is null
  - Transform function errors: wrapped in `try/catch` with error recorded in `report.errors`
  - Capped at 500 entries per category per table with a `Truncated` flag
  - Report is returned as part of the result (`{ sampleTriples, totalTriplesCount, report }`)
  - Report is `null` for sample-mode runs (no tracking overhead)

- **`bin/KGbuilder/KGbuilder_main.js`**: Aggregates per-table reports into `totalReport` keyed by table name; returns `report` in the final callback result (only for non-sample runs)

- **`api/v1/paths/kg/mappings/recreateTriples.js`**: Exposes `report` at the top level of the JSON response for easy client access

- **`public/vocables/modules/tools/mappingModeler/tripleFactory.js`**: Added `downloadReport()` function that, when errors or skipped mappings are present, triggers a browser download of a plain `.txt` file (`triple_report_<source>_<date>.txt`) with sections for errors and skipped mappings (only non-empty sections included). Hooked into `ajaxRecreate` (for recreate-all / recreate-selected flows) and `createTriples` success (for per-table filter-mapping flow, non-sample only).

- **`tests/triplesMaker.report.test.js`**: Added Jest tests covering report initialization, null column URI tracking, transform error recording, successful-run with no entries, and truncation behaviour.

## Decisions & trade-offs

- **In-memory only, no file persistence**: The `report` object lives in the Node.js request lifecycle and is discarded after the HTTP response. Storage was explicitly out of scope per the issue.
- **500-entry cap per category per table**: Prevents unbounded memory growth on large datasets; a `Truncated: true` flag signals that more events occurred.
- **Sample mode excluded**: `tableProcessingParams.report = null` for sample runs — zero overhead on preview calls.
- **Report exposed at two levels in the API response** (`data.report` and `data.result.report`) so both the `recreateTriples` endpoint and the `/kg/triples` endpoint return it consistently.
- **Client download is browser-native** (`Blob` + `URL.createObjectURL`): no additional dependencies needed.
- **Test file added** following existing Jest + ES-module pattern; Jest runner has a pre-existing `ansi-styles` resolution issue in the isolated worktree (symlinked `node_modules`), but syntax was verified with `node --check` and logic with a custom Node.js validation script.

## Tests

- `node --check` on all modified backend/frontend files: **passed**
- Custom Node.js validation script confirming all key patterns exist in modified files: **passed (14/14)**
- `tests/triplesMaker.report.test.js` added (Jest): covers null column URI skip, transform error capture, successful run, and truncation cap
- Jest test suite could not be executed due to a pre-existing `ansi-styles` module resolution failure in the symlinked-node_modules worktree environment (unrelated to this change)