### PR TITLE
feat(upload): display warning when graph contains blank nodes

### DIFF
--- a/mainapp/src/Component/UploadGraphModal.tsx
+++ b/mainapp/src/Component/UploadGraphModal.tsx
@@ -31,6 +31,7 @@ export function UploadGraphModal({ apiUrl, onClose, open, sourceName, indexAfter
     const [uploadfile, setUploadFile] = useState<File[]>([]);
     const [replaceGraph, setReplaceGraph] = useState<boolean>(true);
     const [errorMessage, setErrorMessage] = useState("");
+    const [hasBlankNodes, setHasBlankNodes] = useState<boolean>(false);
     const cancelCurrentOperation = useRef(false);
     const [graphUrl, setGraphUrl] = useState<string>("");
 
@@ -52,6 +53,7 @@ export function UploadGraphModal({ apiUrl, onClose, open, sourceName, indexAfter
         }
         const filesList = Array.from(event.currentTarget.files);
         setUploadFile(filesList);
+        setHasBlankNodes(false);
     };
 
     const uploadSource = async (e: MouseEvent) => {
@@ -205,8 +207,11 @@ export function UploadGraphModal({ apiUrl, onClose, open, sourceName, indexAfter
                     throw new Error("Upload failed");
                 }
 
-                const json = (await res.json()) as { identifier: string };
-                chunkId = json.identifier; // store identifier for the next chunk
+                const json = (await res.json()) as { identifier: string; has_blank_nodes?: boolean };
+                chunkId = json.identifier;
+                if (json.has_blank_nodes === true) {
+                    setHasBlankNodes(true);
+                }
                 return true;
             }
 
@@ -278,6 +283,7 @@ export function UploadGraphModal({ apiUrl, onClose, open, sourceName, indexAfter
                             {errorMessage}
                         </Alert>
                     ) : null}
+                    {hasBlankNodes ? <Alert severity="warning">Warning: This graph contains blank nodes. Consistency of blank nodes may be lost.</Alert> : null}
                     <Stack spacing={2} sx={{ pt: 1 }}>
                         <Stack spacing={1} direction="row" useFlexGap>
                             <Button color="info" component="label" disabled={transferPercent > 0} fullWidth role={undefined} startIcon={<Folder />} tabIndex={-1} variant="outlined">


### PR DESCRIPTION
Add a persistent warning message in the UploadGraphModal when the sls-api detects blank nodes in the uploaded RDF graph.

## Changes

- Add `hasBlankNodes` state to track blank node detection
- Parse `has_blank_nodes` field from sls-api response
- Display permanent warning alert when blank nodes are detected
- Warning persists even if subsequent chunks return `false`
- State resets when user selects a new file

## Warning Message

> Warning: This graph contains blank nodes. Consistency of blank nodes may be lost.

## Technical Details

- Modified: `mainapp/src/Component/UploadGraphModal.tsx`
- The warning is only triggered for file uploads (not URL uploads)
- Uses MUI Alert component with severity="warning"
- Compatible with streaming chunk upload implementation

## Testing

- Build successful with no TypeScript errors
- Warning appears when sls-api returns `has_blank_nodes: true`
- Warning remains visible throughout the upload process
- Warning resets when selecting a different file
