### PR TITLE
Aadd per-profile Virtuoso load threshold to restrictVirtuosoLoad

### DIFF
--- a/api/v1/api-doc.js
+++ b/api/v1/api-doc.js
@@ -357,6 +357,11 @@ const apiDoc = {
                     type: "number",
                     description: "How many user data entries a user of this profile may own. 0 forbids saving any. Omitted, the limit stored on the user account applies.",
                 },
+                maxVirtuosoLoad: {
+                    type: "number",
+                    description:
+                        "Virtuoso load threshold (0-100) above which this profile's users are rejected with 429. Omitted, the global `config.metrics.virtuoso.maxLoad` applies. When several profiles set it, the highest one wins.",
+                },
             },
         },
         DatabaseNames: {

--- a/api/v1/api-doc.js
+++ b/api/v1/api-doc.js
@@ -16,6 +16,9 @@ const apiDoc = {
         restrictQuota: {
             type: "basic",
         },
+        restrictVirtuosoLoad: {
+            type: "basic",
+        },
     },
     definitions: {
         AuthCheck: {

--- a/api/v1/paths/kg/clearGraph.js
+++ b/api/v1/paths/kg/clearGraph.js
@@ -36,7 +36,7 @@ export default function () {
     }
 
     POST.apiDoc = {
-        security: [{ restrictLoggedUser: [], restrictQuota: [] }],
+        security: [{ restrictLoggedUser: [], restrictQuota: [], restrictVirtuosoLoad: [] }],
         summary: "Drop all triples from a KG named graph",
         description:
             "Wipes the entire content of `graphUri` via `KGtripleBuilder.clearGraph` (SPARQL `CLEAR GRAPH`). " + "Used before a full KG rebuild; does not remove the source descriptor itself.",

--- a/api/v1/paths/kg/clearGraph.js
+++ b/api/v1/paths/kg/clearGraph.js
@@ -18,7 +18,7 @@ export default function () {
     }
 
     POST.apiDoc = {
-        security: [{ restrictLoggedUser: [], restrictQuota: [] }],
+        security: [{ restrictLoggedUser: [], restrictQuota: [], restrictVirtuosoLoad: [] }],
         summary: "Drop all triples from a KG named graph",
         description:
             "Wipes the entire content of `graphUri` via `KGtripleBuilder.clearGraph` (SPARQL `CLEAR GRAPH`). " + "Used before a full KG rebuild; does not remove the source descriptor itself.",

--- a/api/v1/paths/rdf/graph.js
+++ b/api/v1/paths/rdf/graph.js
@@ -227,7 +227,7 @@ export default function () {
     }
 
     POST.apiDoc = {
-        security: [{ restrictLoggedUser: [], restrictQuota: [] }],
+        security: [{ restrictLoggedUser: [], restrictQuota: [], restrictVirtuosoLoad: [] }],
         summary: "Upload an RDF file into the graph of a source (chunked)",
         description:
             "Streams an RDF payload into the named graph attached to `source`. The endpoint supports chunked uploads: " +
@@ -263,7 +263,7 @@ export default function () {
     };
 
     GET.apiDoc = {
-        security: [{ restrictLoggedUser: [], restrictQuota: [] }],
+        security: [{ restrictLoggedUser: [], restrictQuota: [], restrictVirtuosoLoad: [] }],
         summary: "Stream the N-Triples content of a source's graph (paginated)",
         description:
             "Returns a slice of the RDF graph of `source` serialised as N-Triples. " +
@@ -303,7 +303,7 @@ export default function () {
     };
 
     DELETE.apiDoc = {
-        security: [{ restrictLoggedUser: [], restrictQuota: [] }],
+        security: [{ restrictLoggedUser: [], restrictQuota: [], restrictVirtuosoLoad: [] }],
         summary: "Drop the named graph attached to a source",
         description:
             "Issues a SPARQL `DROP GRAPH` on the `graphUri` of `source`. The source descriptor itself is **not** removed " +

--- a/api/v1/paths/rdf/graph.js
+++ b/api/v1/paths/rdf/graph.js
@@ -204,7 +204,7 @@ export default function () {
     }
 
     POST.apiDoc = {
-        security: [{ restrictLoggedUser: [], restrictQuota: [] }],
+        security: [{ restrictLoggedUser: [], restrictQuota: [], restrictVirtuosoLoad: [] }],
         summary: "Upload an RDF file into the graph of a source (chunked)",
         description:
             "Streams an RDF payload into the named graph attached to `source`. The endpoint supports chunked uploads: " +
@@ -240,7 +240,7 @@ export default function () {
     };
 
     GET.apiDoc = {
-        security: [{ restrictLoggedUser: [], restrictQuota: [] }],
+        security: [{ restrictLoggedUser: [], restrictQuota: [], restrictVirtuosoLoad: [] }],
         summary: "Stream the N-Triples content of a source's graph (paginated)",
         description:
             "Returns a slice of the RDF graph of `source` serialised as N-Triples. " +
@@ -280,7 +280,7 @@ export default function () {
     };
 
     DELETE.apiDoc = {
-        security: [{ restrictLoggedUser: [], restrictQuota: [] }],
+        security: [{ restrictLoggedUser: [], restrictQuota: [], restrictVirtuosoLoad: [] }],
         summary: "Drop the named graph attached to a source",
         description:
             "Issues a SPARQL `DROP GRAPH` on the `graphUri` of `source`. The source descriptor itself is **not** removed " +

--- a/api/v1/paths/rdf/graph/info.js
+++ b/api/v1/paths/rdf/graph/info.js
@@ -43,7 +43,7 @@ export default function () {
     }
 
     GET.apiDoc = {
-        security: [{ restrictLoggedUser: [], restrictQuota: [] }],
+        security: [{ restrictLoggedUser: [], restrictQuota: [], restrictVirtuosoLoad: [] }],
         summary: "Return graph URI and total triple count for a source",
         description:
             "Lightweight endpoint (a single `COUNT(*)` SPARQL query) used by the UI to display graph size before " +

--- a/api/v1/paths/rdf/graph/metadata.js
+++ b/api/v1/paths/rdf/graph/metadata.js
@@ -49,7 +49,7 @@ export default function () {
     }
 
     POST.apiDoc = {
-        security: [{ restrictLoggedUser: [], restrictQuota: [] }],
+        security: [{ restrictLoggedUser: [], restrictQuota: [], restrictVirtuosoLoad: [] }],
         summary: "Add and/or remove metadata triples on a source's graph",
         description:
             "Applies a delta on the metadata-level triples of the named graph attached to `source`: " +
@@ -127,7 +127,7 @@ export default function () {
         tags: ["RDF"],
     };
     GET.apiDoc = {
-        security: [{ restrictLoggedUser: [], restrictQuota: [] }],
+        security: [{ restrictLoggedUser: [], restrictQuota: [], restrictVirtuosoLoad: [] }],
         summary: "Read metadata triples of a source's graph",
         description: "Returns metadata-level triples (titles, creators, imports, versioning) of the named graph attached to `source`, " + "as fetched by `rdfDataModel.getRdfMetadata`.",
         operationId: "rdfGetGraphMetadata",

--- a/api/v1/paths/rdf/graphUrl.js
+++ b/api/v1/paths/rdf/graphUrl.js
@@ -75,7 +75,7 @@ export default function () {
     }
 
     POST.apiDoc = {
-        security: [{ restrictLoggedUser: [], restrictQuota: [] }],
+        security: [{ restrictLoggedUser: [], restrictQuota: [], restrictVirtuosoLoad: [] }],
         summary: "Load an RDF file from a remote URL into a source's graph",
         description:
             "Server-side fetch of `url` (typically a Turtle/RDF-XML/OWL file), persisted under " +

--- a/api/v1/paths/rdf/graphUrl.js
+++ b/api/v1/paths/rdf/graphUrl.js
@@ -57,7 +57,7 @@ export default function () {
     }
 
     POST.apiDoc = {
-        security: [{ restrictLoggedUser: [], restrictQuota: [] }],
+        security: [{ restrictLoggedUser: [], restrictQuota: [], restrictVirtuosoLoad: [] }],
         summary: "Load an RDF file from a remote URL into a source's graph",
         description:
             "Server-side fetch of `url` (typically a Turtle/RDF-XML/OWL file), persisted under " +

--- a/api/v1/paths/shortestPath.js
+++ b/api/v1/paths/shortestPath.js
@@ -53,7 +53,7 @@ export default function () {
 
     POST.apiDoc = {
         summary: "Get the shortest path between two node",
-        security: [{ restrictLoggedUser: [], restrictQuota: [] }],
+        security: [{ restrictLoggedUser: [], restrictQuota: [], restrictVirtuosoLoad: [] }],
         operationId: "getShortestPath",
         parameters: [
             {

--- a/api/v1/paths/sparql/graphs.js
+++ b/api/v1/paths/sparql/graphs.js
@@ -27,7 +27,7 @@ export default function () {
     }
 
     GET.apiDoc = {
-        security: [{ restrictLoggedUser: [], restrictQuota: [] }],
+        security: [{ restrictLoggedUser: [], restrictQuota: [], restrictVirtuosoLoad: [] }],
         summary: "List RDF graphs accessible to the current user",
         description:
             "Returns the subset of named graphs present in the triplestore whose URI matches the `graphUri` " +

--- a/api/v1/paths/sparqlProxy.js
+++ b/api/v1/paths/sparqlProxy.js
@@ -76,7 +76,7 @@ export default function () {
             "When `body.POST` is truthy, the request is sent as POST and goes through `UserRequestFiltering.filterSparqlRequest` " +
             "which read `FROM` clauses to restrict the query to graphs the current user is allowed to read. ",
 
-        security: [{ restrictLoggedUser: [], restrictQuota: [] }],
+        security: [{ restrictLoggedUser: [], restrictQuota: [], restrictVirtuosoLoad: [] }],
         operationId: "sparqlProxyPost",
         parameters: [
             {
@@ -179,7 +179,7 @@ export default function () {
         description:
             "GET variant of the SPARQL proxy: forwards `query.url` with `query.options` to the target SPARQL server. " +
             "Same access-control filtering as the POST variant when the target matches the configured main `sparql_server.url`.",
-        security: [{ restrictLoggedUser: [], restrictQuota: [] }],
+        security: [{ restrictLoggedUser: [], restrictQuota: [], restrictVirtuosoLoad: [] }],
         operationId: "sparqlProxyGet",
         parameters: [
             {

--- a/api/v1/paths/yasguiQuery.js
+++ b/api/v1/paths/yasguiQuery.js
@@ -72,7 +72,7 @@ export default function () {
 
     POST.apiDoc = {
         summary: "Send a SPARQL query to a different domain",
-        security: [{ restrictLoggedUser: [], restrictQuota: [] }],
+        security: [{ restrictLoggedUser: [], restrictQuota: [], restrictVirtuosoLoad: [] }],
         operationId: "sparqlQuery",
         parameters: [
             {

--- a/app.js
+++ b/app.js
@@ -21,7 +21,7 @@ import userManager from "./bin/user.js";
 import "./bin/authentication.js";
 import { checkMainConfig, readMainConfig } from "./model/config.js";
 import util from "./bin/util.js";
-import { register, httpRequestDuration, httpRequestsTotal, configureVirtuosoMetrics } from "./bin/metrics.js";
+import { register, httpRequestDuration, httpRequestsTotal, configureVirtuosoMetrics, getVirtuosoLoad, maxLoadThreshold } from "./bin/metrics.js";
 
 const app = express();
 import * as Sentry from "@sentry/node";
@@ -35,7 +35,7 @@ import { attachResponseValidator } from "./bin/responseValidator.js";
 import session from "express-session";
 
 const config = readMainConfig();
-configureVirtuosoMetrics(config.metrics?.virtuoso?.maxPending ?? 50);
+configureVirtuosoMetrics(config.metrics?.virtuoso?.maxPending ?? 50, config.metrics?.virtuoso?.maxLoad ?? 80);
 checkMainConfig(config).then((isValid) => {
     if (!isValid) {
         process.exit(1);
@@ -279,6 +279,15 @@ openapi.initialize({
                     }
                     console.error(`Quota error for ${route} ${method}:`, error);
                 }
+            }
+            return Promise.resolve(true);
+        },
+        restrictVirtuosoLoad: async function (req, scope, definition) {
+            if (getVirtuosoLoad() >= maxLoadThreshold) {
+                throw {
+                    status: 429,
+                    message: `Virtuoso server is overloaded (load: ${getVirtuosoLoad().toFixed(1)}%, threshold: ${maxLoadThreshold}%)`,
+                };
             }
             return Promise.resolve(true);
         },

--- a/app.js
+++ b/app.js
@@ -226,6 +226,26 @@ app.get("/metrics", async (req, res) => {
 
 attachResponseValidator(app, apiDoc, { logPath: "logs/schema-mismatches.jsonl" });
 
+/* Resolves the user account from the Bearer token on the request, setting
+ * `req.user` when authentication is enabled. Shared by the security handlers
+ * because express-openapi runs them in parallel, so none can rely on another
+ * having populated `req.user` first. Returns `req.user` (possibly undefined). */
+async function resolveUserFromRequest(req) {
+    const token = req.headers.authorization;
+    if (token !== undefined) {
+        const output = util.parseAuthorizationFromHeader(token);
+
+        // Only accept the Bearer scheme from the Authorization header
+        if (output !== null && output[0] === "Bearer") {
+            const user = await userModel.findUserAccountFromToken(output[1]);
+            if (user) {
+                req.user = user[1];
+            }
+        }
+    }
+    return req.user;
+}
+
 openapi.initialize({
     apiDoc: apiDoc,
     app: app,
@@ -233,18 +253,7 @@ openapi.initialize({
     securityHandlers: {
         restrictQuota: async function (req, scope, definition) {
             if (config.auth != "disabled") {
-                const token = req.headers.authorization;
-                if (token !== undefined) {
-                    const output = util.parseAuthorizationFromHeader(token);
-
-                    // Only accept the Bearer scheme from the Authorization header
-                    if (output !== null && output[0] === "Bearer") {
-                        const user = await userModel.findUserAccountFromToken(output[1]);
-                        if (user) {
-                            req.user = user[1];
-                        }
-                    }
-                }
+                await resolveUserFromRequest(req);
 
                 const user = await userManager.getUser(req.user);
                 const route = req.baseUrl + req.path;
@@ -283,28 +292,34 @@ openapi.initialize({
             return Promise.resolve(true);
         },
         restrictVirtuosoLoad: async function (req, scope, definition) {
-            if (getVirtuosoLoad() >= maxLoadThreshold) {
+            let threshold = maxLoadThreshold;
+            if (config.auth != "disabled") {
+                await resolveUserFromRequest(req);
+                if (req.user) {
+                    const account = await userManager.getUser(req.user);
+                    const accountUser = account?.user;
+                    if (accountUser && (accountUser.login === "admin" || (accountUser.groups || []).includes("admin"))) {
+                        return Promise.resolve(true);
+                    }
+                    if (accountUser) {
+                        const profileThreshold = await profileModel.getMaxVirtuosoLoadForUser(accountUser);
+                        if (profileThreshold !== undefined) {
+                            threshold = profileThreshold;
+                        }
+                    }
+                }
+            }
+            if (getVirtuosoLoad() >= threshold) {
                 throw {
                     status: 429,
-                    message: `Virtuoso server is overloaded (load: ${getVirtuosoLoad().toFixed(1)}%, threshold: ${maxLoadThreshold}%)`,
+                    message: `Virtuoso server is overloaded (load: ${getVirtuosoLoad().toFixed(1)}%, threshold: ${threshold}%)`,
                 };
             }
             return Promise.resolve(true);
         },
         restrictLoggedUser: async function (req, _scopes, _definition) {
             if (config.auth != "disabled") {
-                const token = req.headers.authorization;
-                if (token !== undefined) {
-                    const output = util.parseAuthorizationFromHeader(token);
-
-                    // Only accept the Bearer scheme from the Authorization header
-                    if (output !== null && output[0] === "Bearer") {
-                        const user = await userModel.findUserAccountFromToken(output[1]);
-                        if (user) {
-                            req.user = user[1];
-                        }
-                    }
-                }
+                await resolveUserFromRequest(req);
 
                 if (config.auth == "keycloak") {
                     passport.authenticate("keycloak", { failureRedirect: "/login" });

--- a/app.js
+++ b/app.js
@@ -21,7 +21,7 @@ import userManager from "./bin/user.js";
 import "./bin/authentication.js";
 import { checkMainConfig, readMainConfig } from "./model/config.js";
 import util from "./bin/util.js";
-import { register, httpRequestDuration, httpRequestsTotal } from "./bin/metrics.js";
+import { register, httpRequestDuration, httpRequestsTotal, configureVirtuosoMetrics } from "./bin/metrics.js";
 
 const app = express();
 import * as Sentry from "@sentry/node";
@@ -35,6 +35,7 @@ import { attachResponseValidator } from "./bin/responseValidator.js";
 import session from "express-session";
 
 const config = readMainConfig();
+configureVirtuosoMetrics(config.metrics?.virtuoso?.maxPending ?? 50);
 checkMainConfig(config).then((isValid) => {
     if (!isValid) {
         process.exit(1);
@@ -456,8 +457,8 @@ const basicVocabularies = [
 ];
 
 async function loadBasicVocabularies() {
-    const existingGraphs = await rdfDataModel.getGraphs();
     try {
+        const existingGraphs = await rdfDataModel.getGraphs();
         for (const ontology of basicVocabularies) {
             const matchingGraph = existingGraphs.find((g) => g.name === ontology.graphUri);
             const hasGraph = !!matchingGraph?.count;
@@ -474,8 +475,8 @@ async function loadBasicVocabularies() {
 // Load default graph available in the "graphDownloadUrl" key
 // if no graph is already available in the Virtuoso
 async function loadDefaultGraphs() {
-    const sources = await sourceModel.getAllSources();
     try {
+        const sources = await sourceModel.getAllSources();
         const graphs = await rdfDataModel.getGraphs();
         for (const [, source] of Object.entries(sources)) {
             const graphDownloadUrl = source.graphDownloadUrl;
@@ -484,7 +485,6 @@ async function loadDefaultGraphs() {
                 const matchingGraph = graphs.find((g) => g.name === graphURI);
                 const hasGraph = !!matchingGraph?.count;
                 if (!hasGraph) {
-                    console.log(`Loading graph ${source.graphUri}`);
                     await rdfDataModel.loadGraph(source.graphUri, graphDownloadUrl);
                 }
             }
@@ -494,7 +494,9 @@ async function loadDefaultGraphs() {
     }
 }
 
-void loadBasicVocabularies();
-void loadDefaultGraphs();
+(async () => {
+    await loadBasicVocabularies();
+    await loadDefaultGraphs();
+})();
 
 export default app;

--- a/bin/httpProxy.js
+++ b/bin/httpProxy.js
@@ -15,11 +15,24 @@ import superagent from "superagent";
 import superagent_proxy from "superagent-proxy";
 superagent_proxy(superagent);
 import request from "request";
+import { config } from "../model/config.js";
+import { trackVirtuosoRequest, endVirtuosoRequest } from "./metrics.js";
+
 var proxy = null;
+
+function isVirtuosoUrl(url) {
+    return url && config.sparql_server && url.indexOf(config.sparql_server.url) === 0;
+}
+
 var httpProxy = {
     host: null,
 
     get: function (url, options, callback) {
+        const tracking = isVirtuosoUrl(url);
+        if (tracking) {
+            trackVirtuosoRequest();
+        }
+
         if (!options.headers) {
             options.headers = {};
             /* options.headers={  "Accept": 'application/sparql-results+json',
@@ -40,16 +53,22 @@ var httpProxy = {
         for (var key in options.headers) {
             request.set(key, options.headers[key]);
         }
-        request.end((err, res) => {
-            if (err) {
-                // console.log("HTTP_PROXY_GET_ERROR"+JSON.stringify(err, null, 2))
-                console.log("HTTP_PROXY_GET_ERROR" + err);
-                return callback(err);
+        request.end(async (err, res) => {
+            try {
+                if (err) {
+                    // console.log("HTTP_PROXY_GET_ERROR"+JSON.stringify(err, null, 2))
+                    console.log("HTTP_PROXY_GET_ERROR" + err);
+                    return callback(err);
+                }
+                if (res.text) {
+                    return callback(null, res.text.trim());
+                }
+                callback(null, res.body);
+            } finally {
+                if (tracking) {
+                    endVirtuosoRequest();
+                }
             }
-            if (res.text) {
-                return callback(null, res.text.trim());
-            }
-            callback(null, res.body);
         });
     },
 
@@ -73,6 +92,11 @@ var httpProxy = {
       ,*/
 
     post: function (url, headers, params, callback) {
+        const tracking = isVirtuosoUrl(url);
+        if (tracking) {
+            trackVirtuosoRequest();
+        }
+
         var options = {
             method: "POST",
 
@@ -110,46 +134,52 @@ var httpProxy = {
             console.log(" POST-----------USING  proxy---------" + proxy);
         }
 
-        request(options, function (error, response, body) {
-            if (error) {
-                console.log(error);
-                //  console.log("HTTP_PROXY_ERROR"+JSON.stringify(error, null, 2))
-                return callback(error);
-            } else if (response.statusCode != 200) {
-                return callback(body || "" + " " + response.statusMessage);
-            } else if (headers && headers["Accept"] && headers["Accept"].indexOf("json") < 0) {
-                return callback(null, body);
-            } else if (headers && headers["Content-Type"] && headers["Content-Type"].indexOf("text") > -1) {
-                return callback(null, body);
-            } else if (typeof body === "string") {
-                if (body == "") {
-                    return callback("undefined ERROR ");
-                }
-                body = body.trim();
-                var p = body.toLowerCase().indexOf("bindings");
-                var q = body.toLowerCase().indexOf("results");
-                if (p < 0 && q < 0) {
-                    // error virtuoso
-                    return callback(body);
-                }
-                // if ((body.toLowerCase().indexOf("error") > -1 && body.indexOf("error") < 30) || body.indexOf("{") < 0) return callback(body); //error
-
-                var err = null;
-                try {
-                    body = JSON.parse(body);
-                    //  return callback(null, obj);
-                } catch (e) {
-                    console.log(body);
-                    console.log(e);
-                    err = e.message;
-                    if (e.message.indexOf("Unexpected token V in JSON ") > -1) {
-                        err = e.message;
+        request(options, async function (error, response, body) {
+            try {
+                if (error) {
+                    console.log(error);
+                    //  console.log("HTTP_PROXY_ERROR"+JSON.stringify(error, null, 2))
+                    return callback(error);
+                } else if (response.statusCode != 200) {
+                    return callback(body || "" + " " + response.statusMessage);
+                } else if (headers && headers["Accept"] && headers["Accept"].indexOf("json") < 0) {
+                    return callback(null, body);
+                } else if (headers && headers["Content-Type"] && headers["Content-Type"].indexOf("text") > -1) {
+                    return callback(null, body);
+                } else if (typeof body === "string") {
+                    if (body == "") {
+                        return callback("undefined ERROR ");
                     }
-                } finally {
-                    return callback(err, body);
+                    body = body.trim();
+                    var p = body.toLowerCase().indexOf("bindings");
+                    var q = body.toLowerCase().indexOf("results");
+                    if (p < 0 && q < 0) {
+                        // error virtuoso
+                        return callback(body);
+                    }
+                    // if ((body.toLowerCase().indexOf("error") > -1 && body.indexOf("error") < 30) || body.indexOf("{") < 0) return callback(body); //error
+
+                    var err = null;
+                    try {
+                        body = JSON.parse(body);
+                        //  return callback(null, obj);
+                    } catch (e) {
+                        console.log(body);
+                        console.log(e);
+                        err = e.message;
+                        if (e.message.indexOf("Unexpected token V in JSON ") > -1) {
+                            err = e.message;
+                        }
+                    } finally {
+                        return callback(err, body);
+                    }
+                } else {
+                    return callback(null, body);
                 }
-            } else {
-                return callback(null, body);
+            } finally {
+                if (tracking) {
+                    endVirtuosoRequest();
+                }
             }
         });
     },

--- a/bin/httpProxy.js
+++ b/bin/httpProxy.js
@@ -15,13 +15,13 @@ import superagent from "superagent";
 import superagent_proxy from "superagent-proxy";
 superagent_proxy(superagent);
 import request from "request";
-import { config } from "../model/config.js";
+import ConfigManager from "./configManager.js";
 import { trackVirtuosoRequest, endVirtuosoRequest } from "./metrics.js";
 
 var proxy = null;
 
 function isVirtuosoUrl(url) {
-    return url && config.sparql_server && url.indexOf(config.sparql_server.url) === 0;
+    return url && ConfigManager.config && ConfigManager.config.sparql_server && url.indexOf(ConfigManager.config.sparql_server.url) === 0;
 }
 
 var httpProxy = {

--- a/bin/metrics.js
+++ b/bin/metrics.js
@@ -20,6 +20,7 @@ register.registerMetric(httpRequestsTotal);
 
 let virtuosoPending = 0;
 let maxPending = 50;
+let maxLoadThreshold = 80;
 
 const virtuosoSparqlPendingQueries = new client.Gauge({
     name: "virtuoso_sparql_pending_queries",
@@ -51,10 +52,18 @@ export function endVirtuosoRequest() {
     }
 }
 
-export function configureVirtuosoMetrics(max) {
+export function configureVirtuosoMetrics(max, maxLoad) {
     if (typeof max === "number" && max > 0) {
         maxPending = max;
     }
+    if (typeof maxLoad === "number" && maxLoad > 0 && maxLoad <= 100) {
+        maxLoadThreshold = maxLoad;
+    }
 }
 
-export { register, httpRequestDuration, httpRequestsTotal };
+export function getVirtuosoLoad() {
+    const load = (virtuosoPending / maxPending) * 100;
+    return Math.min(100, load);
+}
+
+export { register, httpRequestDuration, httpRequestsTotal, maxLoadThreshold };

--- a/bin/metrics.js
+++ b/bin/metrics.js
@@ -18,4 +18,43 @@ const httpRequestsTotal = new client.Counter({
 register.registerMetric(httpRequestDuration);
 register.registerMetric(httpRequestsTotal);
 
+let virtuosoPending = 0;
+let maxPending = 50;
+
+const virtuosoSparqlPendingQueries = new client.Gauge({
+    name: "virtuoso_sparql_pending_queries",
+    help: "Number of SPARQL requests currently in-flight to the Virtuoso server",
+    collect() {
+        this.set(virtuosoPending);
+    },
+});
+
+const virtuosoSparqlLoad = new client.Gauge({
+    name: "virtuoso_sparql_load",
+    help: "Virtuoso load ratio (0-100) derived from in-flight SPARQL requests; 0 at 0 pending, 100 at maxPending or more",
+    collect() {
+        const load = (virtuosoPending / maxPending) * 100;
+        this.set(Math.min(100, load));
+    },
+});
+
+register.registerMetric(virtuosoSparqlPendingQueries);
+register.registerMetric(virtuosoSparqlLoad);
+
+export function trackVirtuosoRequest() {
+    virtuosoPending++;
+}
+
+export function endVirtuosoRequest() {
+    if (virtuosoPending > 0) {
+        virtuosoPending--;
+    }
+}
+
+export function configureVirtuosoMetrics(max) {
+    if (typeof max === "number" && max > 0) {
+        maxPending = max;
+    }
+}
+
 export { register, httpRequestDuration, httpRequestsTotal };

--- a/config_templates/mainConfig.json.default
+++ b/config_templates/mainConfig.json.default
@@ -106,7 +106,8 @@
             "password": "changeme"
         },
         "virtuoso": {
-            "maxPending": 50
+            "maxPending": 20,
+            "maxLoad": 80
         }
     }
 }

--- a/config_templates/mainConfig.json.default
+++ b/config_templates/mainConfig.json.default
@@ -104,6 +104,9 @@
             "enabled": true,
             "username": "prometheus",
             "password": "changeme"
+        },
+        "virtuoso": {
+            "maxPending": 50
         }
     }
 }

--- a/docs/docs/admindoc/configuration/rights-and-quotas.md
+++ b/docs/docs/admindoc/configuration/rights-and-quotas.md
@@ -192,3 +192,27 @@ The *Quotas* tab of the user settings shows, for each limit that has a usage, wh
 user currently holds and the cap resolved for them. The triple figures are measured
 against the triplestore when the page is opened, so a deletion made outside the
 application is already taken into account.
+
+## Virtuoso load protection
+
+A profile may carry a `maxVirtuosoLoad` (0-100, the *Max Virtuoso load (%)* field of the
+Config Editor). It is not a quota on a user's stock: it is the load threshold above which
+the heavy SPARQL and RDF endpoints of that profile's users are refused with `429` while
+the server is busy. It exists to shield the triplestore from a burst of expensive queries
+(upload, drop or stream of a graph, metadata, `graphUrl`, `shortestPath`, the SPARQL proxy
+and the YASGUI query).
+
+How the threshold is resolved for a given user:
+
+- An **administrator** — the `admin` login or any member of the `admin` group — is never
+  capped, whatever the profiles say.
+- Otherwise the **highest** `maxVirtuosoLoad` among the user's profiles applies. When
+  several profiles set it, the most permissive (the highest threshold) wins, mirroring how
+  the other limits are resolved.
+- When no profile of the user sets one, the **global** `config.metrics.virtuoso.maxLoad`
+  threshold applies (see [souslesens.md](souslesens.md)).
+
+A field left empty means "this profile does not set a threshold", so the global value
+applies. The estimated load behind the check is derived from the in-flight SPARQL requests
+exposed by the `virtuoso_sparql_load` metric; the refusal happens as soon as that estimate
+reaches the resolved threshold.

--- a/docs/docs/admindoc/configuration/souslesens.md
+++ b/docs/docs/admindoc/configuration/souslesens.md
@@ -11,11 +11,28 @@ The `mainConfig.json` contain all the `souslesensVocables` configuration.
 -   `souslesensUrlForVirtuoso`: the URL of SousLeSens, from Virtuoso. It's used to pull RDF data
     from the SousLeSens server.
 -   `listenPort`: The listen port of SousLeSens.
--   `serverUrl`:
+-   `serverUrl`: The base URL used to build the graph traversal queries.
 -   `theme`: the UI theme of SousLeSens
     -   `selector`: Display a selector to choose the UI theme
     -   `defaultTheme`: Set the fallback theme
 -   `auth`: The authentication mechanisme. Can be `local`, `keycloak`, `auth0`, `database` or `disabled`
+-   `cookieSameSite`: The value of the `SameSite` attribute of the session cookies
+-   `cookieSecure`: Mark the session cookies as `Secure` (sent over HTTPS only)
+-   `cookieSecureTrustProxy`: Trust the `X-Forwarded-Proto` header to set the `Secure` flag behind a
+    reverse proxy
+-   `cookieMaxAge`: The lifetime of the session cookies, in milliseconds
+-   `defaultGroups`: The groups assigned by default to the users
+-   `logs`: The logger configuration for the server
+    -   `directory`: The path to the directory where the log files are stored
+    -   `useFileLogger`: Set to `false` to disable the file logger and the writing on the filesystem
+    -   `useSymlink`: Set to `false` to disable the creation of symlinks in the logs directory. Useful for the operating system which have a hard time to manage them.
+-   `default_lang`: The default language of the application, used for the SPARQL queries and labels
+-   `sentryDsnNode`: The sentry DSN for the server
+-   `sentryDsnJsFront`: The sentry DSN for the client
+-   `formalOntologySourceLabel`: The label of the formal ontology source, added as read-only to the
+    users
+-   `tools_available`: The list of available tools. Values: `lineage`, `KGcreator`, `KGquery`,
+    `admin`, `ConfigEditor`, `GraphManagement`, `UserSettings`, `OntoCreator`
 -   `auth0`: If `auth` is set to `auth0`, the auth0 configuration.
     -   `domain`: the `auth0` domain
     -   `clientID`: Auth0 clientID
@@ -24,38 +41,28 @@ The `mainConfig.json` contain all the `souslesensVocables` configuration.
     -   `api`: Auth0 API configuration
         -   `clientID`: Auth0 API clientID
         -   `clientSecret`: Auth0 API clientSecret
+    -   `usernameMapping`: The Auth0 field used as the login. Can be `email`, `nickname` or `name`
+    -   `useAuth0Roles`: Set to `true` to use the Auth0 roles as SLS groups
 -   `keycloak`: If `auth` is set to `keycloak`, the KeyCloak configuration
     -   `realm`: The KeyCloak realm
     -   `publicClient`: `true` if the client is public
     -   `clientID`: The KeyCloak clientID
     -   `clientSecret`: The KeyCloak clientSecret
     -   `authServerURL`: The public URL of the KeyCloak server
--   `authenticationDatabase`: If `auth` is `database`, The database configuration
-    -   `user`: The database user
-    -   `password`: The database password
-    -   `host`: The database host
-    -   `port`: The database port
-    -   `database`: The database name
-    -   `table`: The database table that contains the users
-    -   `loginColumn`: The column on the table that contains the login
-    -   `groupsColumn`: The column on the table that contains the groups
--   `sentryDnsNode`: The sentry DSN for the server
--   `sentryDnsJsFront`: The sentry DSN for the client
--   `slsPyApi`: [sls-py-api](https://github.com/souslesens/sls-py-api) configuration
-    -   `enabled`: `true` if sls-py-api is enabled
-    -   `url`: The url of sls-py-api (with protocol and port)
+-   `health_enabled_services`: The services checked by the `/api/v1/health` endpoint. Default:
+    `virtuoso`, `elasticsearch`, `spacyserver`
 -   `sparql_server`: The SPARQL server configuration (Virtuoso)
     -   `url`: The url of the SPARQL server, with protocol and port and path
     -   `user`: Virtuoso user
     -   `password`: Virtuoso password
--   `Elasticsearch`: The Elasticsearch server configuration
+-   `ElasticSearch`: The Elasticsearch server configuration
 
     **Compatibility:** Only Elasticsearch 8.x is supported. Elasticsearch 7 and earlier versions are not compatible.
 
     -   `url`: The ElasticSearch URL, with protocol and port
     -   `user`: The ElasticSearch user
     -   `password`: The ElasticSearch password
-    -   `skipSslVerify`: Set to `false` to skip SSL verify (with self-signed certs)
+    -   `skipSslVerify`: Set to `true` to skip SSL verify (with self-signed certs)
     -   `other_servers`: List of other ElasticSearch nodes
     -   `searchChunkSize`: Size of chunk for the indices search
 
@@ -63,19 +70,38 @@ The `mainConfig.json` contain all the `souslesensVocables` configuration.
 -   `jowlServer`:
     -   `enabled`: `true` if the [JOWL](https://github.com/souslesens/jowl) server is enabled
     -   `url`: The JOWL URL, with protocol and port
+-   `slsPyApi`: [sls-py-api](https://github.com/souslesens/sls-py-api) configuration
+    -   `enabled`: `true` if sls-py-api is enabled
+    -   `url`: The url of sls-py-api (with protocol and port)
 -   `llm`: The LLM provider configuration used by AI features.
     -   `provider`: Active provider. Supported values: `anthropic`, `openrouter`, `ollama`.
     -   `<provider>`: Provider-specific settings. The section name must match `provider`.
+-   `database`: The database configuration used to store the users
+    -   `user`: The database user
+    -   `password`: The database password
+    -   `host`: The database host
+    -   `database`: The database name
+    -   `port`: The database port
+-   `annotator`: The annotator configuration (optional)
+    -   `tikaServerUrl`: The URL of the Apache Tika server
+    -   `spacyServerUrl`: The URL of the spaCy server
+    -   `parsedDocumentsHomeDir`: The home directory of the parsed documents. `null` to disable.
+    -   `uploadDirPath`: The path of the upload directory. `null` to disable.
 -   `wiki`: The wiki configuration
     -   `url`: The wiki URL, with protocol and port
--   `logs`: The logger configuration for the server
-    -   `directory`: The path to the directory where the log files are stored
-    -   `useFileLogger`: Set to `false` to disable the file logger and the writing on the filesystem
-    -   `useSymlink`: Set to `false` to disable the creation of symlinks in the logs directory. Useful for the operating system which have a hard time to manage them.
 -   `userData`: The configuration of the userData file management system
     -   `location`: the system used to store the file content (`file` or `database`)
     -   `maximumFileSize`: the maximum file content size allowed in the database (in bytes)
+-   `sparqlDownloadLimit`: The maximum number of rows per page when downloading SPARQL results from
+    the `/api/v1/rdf/graph` endpoints. Maximum `1000000`.
+-   `generalQuota`: The general quotas per API route and HTTP method. A mapping of
+    `{ route: { method: number } }`, for example `{ "source": { "GET": 10 } }`.
 -   `metrics`: The server metrics configuration
+    -   `enabled`: Set to `true` to expose the metrics
+    -   `auth`: The basic authentication protecting the `/metrics` endpoint
+        -   `enabled`: `true` to enable the basic authentication
+        -   `username`: The username
+        -   `password`: The password
     -   `virtuoso`: The Virtuoso load protection settings. These back the `restrictVirtuosoLoad`
         security handler, which answers `429` to the heavy SPARQL/RDF endpoints once the estimated
         load crosses a threshold.

--- a/docs/docs/admindoc/configuration/souslesens.md
+++ b/docs/docs/admindoc/configuration/souslesens.md
@@ -75,6 +75,19 @@ The `mainConfig.json` contain all the `souslesensVocables` configuration.
 -   `userData`: The configuration of the userData file management system
     -   `location`: the system used to store the file content (`file` or `database`)
     -   `maximumFileSize`: the maximum file content size allowed in the database (in bytes)
+-   `metrics`: The server metrics configuration
+    -   `virtuoso`: The Virtuoso load protection settings. These back the `restrictVirtuosoLoad`
+        security handler, which answers `429` to the heavy SPARQL/RDF endpoints once the estimated
+        load crosses a threshold.
+        -   `maxPending`: Number of in-flight SPARQL requests above which the estimated load is
+            considered to be 100%. The load ratio is `pending / maxPending × 100`, capped at 100.
+            Default `50`.
+        -   `maxLoad`: Global load threshold (0-100), in percent, above which protected endpoints
+            answer `429`. It applies to users whose profiles define no `maxVirtuosoLoad` (see
+            [rights-and-quotas](rights-and-quotas.md)). Default `80`.
+
+    **Note:** `maxPending` here is the scale the estimated load is measured against, not the
+    threshold that triggers the refusal; the refusal threshold is `maxLoad`.
 
 ### LLM provider configuration
 

--- a/mainapp/src/Component/ProfilesTable.tsx
+++ b/mainapp/src/Component/ProfilesTable.tsx
@@ -581,6 +581,8 @@ const ProfileForm = ({ profile = defaultProfile(ulid()), create = false, me = ""
         profileModel.profileForm.quota = simplifiedQuotaObj;
         const rawMaxNtExportTriples = profileModel.profileForm.maxNtExportTriples;
         profileModel.profileForm.maxNtExportTriples = rawMaxNtExportTriples || rawMaxNtExportTriples === 0 ? Number(rawMaxNtExportTriples) : undefined;
+        const rawMaxVirtuosoLoad = profileModel.profileForm.maxVirtuosoLoad;
+        profileModel.profileForm.maxVirtuosoLoad = rawMaxVirtuosoLoad ? Number(rawMaxVirtuosoLoad) : undefined;
         const rawMaxNumberCreatedSource = profileModel.profileForm.maxNumberCreatedSource;
         profileModel.profileForm.maxNumberCreatedSource = rawMaxNumberCreatedSource || rawMaxNumberCreatedSource === 0 ? Number(rawMaxNumberCreatedSource) : undefined;
         /* `=== 0` on every one of them: an empty field means "this profile does not
@@ -1000,6 +1002,26 @@ const ProfileForm = ({ profile = defaultProfile(ulid()), create = false, me = ""
                                                 endAdornment: (
                                                     <InputAdornment position="end">
                                                         <HelpTooltip title="How many user data entries a user of this profile may own. When several profiles set it, the highest one wins." />
+                                                    </InputAdornment>
+                                                ),
+                                            }}
+                                        />
+                                    </Stack>
+                                    <Stack spacing={2} useFlexGap>
+                                        <Typography variant="subtitle2">Virtuoso load</Typography>
+                                        <TextField
+                                            fullWidth
+                                            type="number"
+                                            id="maxVirtuosoLoad"
+                                            label="Max Virtuoso load (%)"
+                                            helperText="Empty: the global threshold applies"
+                                            value={profileModel.profileForm.maxVirtuosoLoad ?? ""}
+                                            onChange={handleFieldUpdate("maxVirtuosoLoad")}
+                                            InputProps={{
+                                                inputProps: { min: 1, max: 100 },
+                                                endAdornment: (
+                                                    <InputAdornment position="end">
+                                                        <HelpTooltip title="Virtuoso load threshold (0-100) above which this profile's users are rejected with 429. When several profiles set it, the highest one wins." />
                                                     </InputAdornment>
                                                 ),
                                             }}

--- a/mainapp/src/Component/UploadGraphModal.tsx
+++ b/mainapp/src/Component/UploadGraphModal.tsx
@@ -32,6 +32,7 @@ export function UploadGraphModal({ apiUrl, onClose, open, sourceName, indexAfter
     const [replaceGraph, setReplaceGraph] = useState<boolean>(true);
     const [errorMessage, setErrorMessage] = useState("");
     const [hasBlankNodes, setHasBlankNodes] = useState<boolean>(false);
+    const [blankNodesConverted, setBlankNodesConverted] = useState<boolean>(false);
     const cancelCurrentOperation = useRef(false);
     const [graphUrl, setGraphUrl] = useState<string>("");
 
@@ -54,6 +55,7 @@ export function UploadGraphModal({ apiUrl, onClose, open, sourceName, indexAfter
         const filesList = Array.from(event.currentTarget.files);
         setUploadFile(filesList);
         setHasBlankNodes(false);
+        setBlankNodesConverted(false);
     };
 
     const uploadSource = async (e: MouseEvent) => {
@@ -207,10 +209,13 @@ export function UploadGraphModal({ apiUrl, onClose, open, sourceName, indexAfter
                     throw new Error("Upload failed");
                 }
 
-                const json = (await res.json()) as { identifier: string; has_blank_nodes?: boolean };
+                const json = (await res.json()) as { identifier: string; has_blank_nodes?: boolean; blank_nodes_converted?: boolean };
                 chunkId = json.identifier;
                 if (json.has_blank_nodes === true) {
                     setHasBlankNodes(true);
+                }
+                if (json.blank_nodes_converted === true) {
+                    setBlankNodesConverted(true);
                 }
                 return true;
             }
@@ -270,6 +275,8 @@ export function UploadGraphModal({ apiUrl, onClose, open, sourceName, indexAfter
         setTransferPercent(0);
         setUploadFile([]);
         setErrorMessage("");
+        setHasBlankNodes(false);
+        setBlankNodesConverted(false);
         onClose();
     };
 
@@ -283,7 +290,11 @@ export function UploadGraphModal({ apiUrl, onClose, open, sourceName, indexAfter
                             {errorMessage}
                         </Alert>
                     ) : null}
-                    {hasBlankNodes ? <Alert severity="warning">Warning: This graph contains blank nodes. Consistency of blank nodes may be lost.</Alert> : null}
+                    {hasBlankNodes && blankNodesConverted ? (
+                        <Alert severity="info">Blank nodes were detected and converted to URIs.</Alert>
+                    ) : hasBlankNodes ? (
+                        <Alert severity="warning">Warning: This graph contains blank nodes. Consistency of blank nodes may be lost.</Alert>
+                    ) : null}
                     <Stack spacing={2} sx={{ pt: 1 }}>
                         <Stack spacing={1} direction="row" useFlexGap>
                             <Button color="info" component="label" disabled={transferPercent > 0} fullWidth role={undefined} startIcon={<Folder />} tabIndex={-1} variant="outlined">

--- a/mainapp/src/Profile.ts
+++ b/mainapp/src/Profile.ts
@@ -121,6 +121,7 @@ type ProfileJson = {
     maxWritableTriplesPerUser?: number;
     maxUploadTriplesPerUser?: number;
     maxUserDataRecordsPerUser?: number;
+    maxVirtuosoLoad?: number;
 };
 
 const decodeProfile = (key: string, profile: ProfileJson): Profile => {
@@ -141,6 +142,7 @@ const decodeProfile = (key: string, profile: ProfileJson): Profile => {
         maxWritableTriplesPerUser: profile.maxWritableTriplesPerUser,
         maxUploadTriplesPerUser: profile.maxUploadTriplesPerUser,
         maxUserDataRecordsPerUser: profile.maxUserDataRecordsPerUser,
+        maxVirtuosoLoad: profile.maxVirtuosoLoad,
     };
 };
 
@@ -169,6 +171,7 @@ const ProfileSchema = z.object({
     maxWritableTriplesPerUser: z.number().int().nonnegative().optional(),
     maxUploadTriplesPerUser: z.number().int().nonnegative().optional(),
     maxUserDataRecordsPerUser: z.number().int().nonnegative().optional(),
+    maxVirtuosoLoad: z.number().positive().max(100).optional(),
 });
 
 export const ProfileSchemaCreate = ProfileSchema.merge(
@@ -200,6 +203,7 @@ export const defaultProfile = (uuid: string): Profile => {
         maxWritableTriplesPerUser: undefined,
         maxUploadTriplesPerUser: undefined,
         maxUserDataRecordsPerUser: undefined,
+        maxVirtuosoLoad: undefined,
     };
 };
 export { getProfiles, deleteProfile, ProfileSchema };

--- a/model/config.js
+++ b/model/config.js
@@ -200,6 +200,12 @@ const MainConfigObject = z
                         password: z.string().min(1),
                     })
                     .strict(),
+                virtuoso: z
+                    .object({
+                        maxPending: z.number().positive().default(50),
+                    })
+                    .strict()
+                    .optional(),
             })
             .strict(),
     })

--- a/model/config.js
+++ b/model/config.js
@@ -203,6 +203,7 @@ const MainConfigObject = z
                 virtuoso: z
                     .object({
                         maxPending: z.number().positive().default(50),
+                        maxLoad: z.number().positive().max(100).default(80),
                     })
                     .strict()
                     .optional(),

--- a/model/profiles.js
+++ b/model/profiles.js
@@ -30,6 +30,7 @@ const ProfileObject = z
         maxWritableTriplesPerUser: z.number().int().nonnegative().optional(),
         maxUploadTriplesPerUser: z.number().int().nonnegative().optional(),
         maxUserDataRecordsPerUser: z.number().int().nonnegative().optional(),
+        maxVirtuosoLoad: z.number().positive().max(100).optional(),
         _type: z.string().default("profile"),
     })
     .strict();
@@ -81,6 +82,7 @@ class ProfileModel {
         max_writable_triples: profile.maxWritableTriplesPerUser ?? null,
         max_upload_triples: profile.maxUploadTriplesPerUser ?? null,
         max_user_data_records: profile.maxUserDataRecordsPerUser ?? null,
+        max_virtuoso_load: profile.maxVirtuosoLoad ?? null,
         schema_types: profile.allowedSourceSchemas || [],
     });
 
@@ -119,6 +121,7 @@ class ProfileModel {
                 maxWritableTriplesPerUser: profile.max_writable_triples ?? undefined,
                 maxUploadTriplesPerUser: profile.max_upload_triples ?? undefined,
                 maxUserDataRecordsPerUser: profile.max_user_data_records ?? undefined,
+                maxVirtuosoLoad: profile.max_virtuoso_load ?? undefined,
             },
         ];
     };
@@ -406,6 +409,29 @@ class ProfileModel {
         }
 
         return maxNtExportTriples;
+    };
+
+    /**
+     * Return the max Virtuoso load threshold (0-100) a user may tolerate, across all their profiles.
+     * Admin users (login "admin" or holding the "admin" profile) are never capped.
+     * @param {UserAccount} user - the user whose profiles are inspected
+     * @returns {Promise<number|undefined>} - maximum allowed load threshold, or undefined if unlimited (admin or no profile defines one)
+     */
+    getMaxVirtuosoLoadForUser = async (user) => {
+        if (user.login === "admin" || user.groups?.includes("admin")) {
+            return undefined;
+        }
+
+        const userProfiles = await this.getUserProfiles(user);
+        let maxVirtuosoLoad;
+
+        for (const profile of Object.values(userProfiles)) {
+            if (typeof profile.maxVirtuosoLoad === "number" && (maxVirtuosoLoad === undefined || profile.maxVirtuosoLoad > maxVirtuosoLoad)) {
+                maxVirtuosoLoad = profile.maxVirtuosoLoad;
+            }
+        }
+
+        return maxVirtuosoLoad;
     };
 
     /** The numeric caps a profile may carry, and that a user may also carry on their account. */

--- a/model/rdfData.js
+++ b/model/rdfData.js
@@ -2,6 +2,7 @@ import { readMainConfig } from "./config.js";
 import DigestClient from "digest-fetch";
 import fetch from "node-fetch";
 import { RDF_FORMATS_MIMETYPES, sleep } from "./utils.js";
+import { trackVirtuosoRequest, endVirtuosoRequest } from "../bin/metrics.js";
 
 // Number of triples moved per SPARQL Update batch in moveGraph. Keeps each request small enough
 // to avoid the triplestore's query-execution timeout on graphs with many triples.
@@ -35,23 +36,29 @@ class RdfDataModel {
             format: RDF_FORMATS_MIMETYPES[format],
         });
         const url = new URL(`${this.endpointUrl}?${urlParams.toString()}`).href;
-        let response;
-        if (this.endpointUser && this.endpointPassword) {
-            const client = new DigestClient(this.endpointUser, this.endpointPassword, { basic: false });
-            response = await client.fetch(url);
-        } else {
-            response = await fetch(url);
-        }
-        if (response.status !== 200) {
-            throw new Error(await response.text());
-        }
-        if (format === "json") {
-            const json = await response.json();
-            const bindings = json["results"]["bindings"];
-            return bindings;
-        } else {
-            const nt = await response.text();
-            return nt;
+
+        trackVirtuosoRequest();
+        try {
+            let response;
+            if (this.endpointUser && this.endpointPassword) {
+                const client = new DigestClient(this.endpointUser, this.endpointPassword, { basic: false });
+                response = await client.fetch(url);
+            } else {
+                response = await fetch(url);
+            }
+            if (response.status !== 200) {
+                throw new Error(await response.text());
+            }
+            if (format === "json") {
+                const json = await response.json();
+                const bindings = json["results"]["bindings"];
+                return bindings;
+            } else {
+                const nt = await response.text();
+                return nt;
+            }
+        } finally {
+            endVirtuosoRequest();
         }
     };
 

--- a/scripts/migrations/migration_3.16.0_profiles_max_virtuoso_load.js
+++ b/scripts/migrations/migration_3.16.0_profiles_max_virtuoso_load.js
@@ -1,0 +1,80 @@
+import fs from "fs";
+import knex from "knex";
+import path from "path";
+import yargs from "yargs/yargs";
+import { hideBin } from "yargs/helpers";
+
+/* The Virtuoso load threshold lives only on the profile: left null, the global
+ * `config.metrics.virtuoso.maxLoad` applies as the fallback. */
+const limitColumn = "max_virtuoso_load";
+
+const readConfig = (configDirectory) => {
+    const configPath = path.resolve(configDirectory, "mainConfig.json");
+    return JSON.parse(fs.readFileSync(configPath, { encoding: "utf-8" }));
+};
+
+const migrateTable = async (configDirectory, writeMode, tableName) => {
+    const configJSON = readConfig(configDirectory);
+
+    const connection = await knex({ client: "pg", connection: configJSON.database });
+    if (await connection.schema.hasColumn(tableName, limitColumn)) {
+        console.info(`The table ${tableName} is already up to date`);
+        connection.destroy();
+        return;
+    }
+
+    if (writeMode) {
+        await connection.schema.alterTable(tableName, function (table) {
+            table.integer(limitColumn);
+        });
+        console.info(`The migration is done on ${tableName}`);
+    } else {
+        console.info(`Will add ${limitColumn} to ${tableName}`);
+    }
+    connection.destroy();
+};
+
+/* The views list their columns one by one, so they have to be dropped and read
+ * again from the schema files, which now carry the new one. */
+const migrateView = async (configDirectory, writeMode, viewName, schemaFile) => {
+    const configJSON = readConfig(configDirectory);
+
+    const connection = await knex({ client: "pg", connection: configJSON.database });
+    const viewSchema = path.resolve("scripts", "sql", schemaFile);
+    if (await connection.schema.hasColumn(viewName, limitColumn)) {
+        console.info(`The view ${viewName} is already up to date`);
+        connection.destroy();
+        return;
+    }
+
+    if (writeMode) {
+        await connection.schema.dropViewIfExists(viewName);
+        await connection.raw(fs.readFileSync(viewSchema, "utf-8"));
+        console.info(`The script ${viewSchema} have been executed`);
+    } else {
+        console.info(`Will rebuild the view ${viewName}`);
+    }
+    connection.destroy();
+};
+
+const main = async () => {
+    const argv = yargs(hideBin(process.argv))
+        .alias("c", "config")
+        .describe("c", "Path to the config directory")
+        .alias("w", "write")
+        .describe("w", "Write the migration in the file")
+        .boolean("w")
+        .demandOption(["config"])
+        .help().argv;
+
+    console.info(argv.write ? "🚧 Prepare the migration…" : "🔧 Dry run mode…");
+    await migrateTable(argv.config, argv.write, "profiles");
+    await migrateView(argv.config, argv.write, "profiles_list", "011-profiles-view.sql");
+};
+
+main()
+    .then(() => process.exit(0))
+    .catch((err) => {
+        console.error(err);
+        process.exit(1);
+    });

--- a/scripts/sql/010-profiles.sql
+++ b/scripts/sql/010-profiles.sql
@@ -17,5 +17,6 @@ create table if not exists profiles(
        -- Zero is a decision: it forbids.
        max_writable_triples  integer,
        max_upload_triples    integer,
-       max_user_data_records integer
-);
+       max_user_data_records integer,
+       max_virtuoso_load     integer
+ );

--- a/scripts/sql/011-profiles-view.sql
+++ b/scripts/sql/011-profiles-view.sql
@@ -1,5 +1,5 @@
 -- Add a view to retrieve the profiles and set the schema_types as texts array
 create view profiles_list as
        select label, theme, allowed_tools, allowed_databases, access_control, is_shared, schema_types::text[], quota, max_nt_export_triples, create_source, maximum_source,
-              max_writable_triples, max_upload_triples, max_user_data_records
+              max_writable_triples, max_upload_triples, max_user_data_records, max_virtuoso_load
        from profiles;

--- a/tests/data/database/profiles.json
+++ b/tests/data/database/profiles.json
@@ -24,7 +24,8 @@
         "maximum_source": 2,
         "max_writable_triples": 1000,
         "max_upload_triples": 500,
-        "max_user_data_records": 20
+        "max_user_data_records": 20,
+        "max_virtuoso_load": 70
     },
     {
         "id": "3",
@@ -40,7 +41,8 @@
         "create_source": false,
         "maximum_source": 10,
         "max_writable_triples": 5000,
-        "max_upload_triples": 0
+        "max_upload_triples": 0,
+        "max_virtuoso_load": 90
     },
     {
         "id": "4",

--- a/tests/jest/model.profiles.test.js
+++ b/tests/jest/model.profiles.test.js
@@ -71,6 +71,7 @@ describe("Test the Profilemodel module", () => {
             maxWritableTriplesPerUser: 1000,
             maxUploadTriplesPerUser: 500,
             maxUserDataRecordsPerUser: 20,
+            maxVirtuosoLoad: 70,
         });
     });
 
@@ -122,6 +123,7 @@ describe("Test the Profilemodel module", () => {
             maxWritableTriplesPerUser: undefined,
             maxUploadTriplesPerUser: undefined,
             maxUserDataRecordsPerUser: undefined,
+            maxVirtuosoLoad: undefined,
         });
     });
 
@@ -143,6 +145,7 @@ describe("Test the Profilemodel module", () => {
             maxWritableTriplesPerUser: undefined,
             maxUploadTriplesPerUser: undefined,
             maxUserDataRecordsPerUser: undefined,
+            maxVirtuosoLoad: undefined,
         });
     });
 
@@ -226,6 +229,7 @@ describe("Test the Profilemodel module", () => {
             max_writable_triples: null,
             max_upload_triples: null,
             max_user_data_records: null,
+            max_virtuoso_load: null,
             schema_types: [],
         });
     });
@@ -245,6 +249,7 @@ describe("Test the Profilemodel module", () => {
             max_writable_triples: null,
             max_upload_triples: null,
             max_user_data_records: null,
+            max_virtuoso_load: null,
             schema_types: [],
         });
     });
@@ -264,6 +269,7 @@ describe("Test the Profilemodel module", () => {
             max_writable_triples: null,
             max_upload_triples: null,
             max_user_data_records: null,
+            max_virtuoso_load: null,
             schema_types: [],
         });
     });
@@ -298,6 +304,7 @@ describe("Test the Profilemodel module", () => {
                 maxWritableTriplesPerUser: undefined,
                 maxUploadTriplesPerUser: undefined,
                 maxUserDataRecordsPerUser: undefined,
+                maxVirtuosoLoad: undefined,
             },
         ]);
     });
@@ -333,6 +340,7 @@ describe("Test the Profilemodel module", () => {
                 maxWritableTriplesPerUser: undefined,
                 maxUploadTriplesPerUser: undefined,
                 maxUserDataRecordsPerUser: undefined,
+                maxVirtuosoLoad: undefined,
             },
         ]);
     });
@@ -369,6 +377,7 @@ describe("Test the Profilemodel module", () => {
                 maxWritableTriplesPerUser: undefined,
                 maxUploadTriplesPerUser: undefined,
                 maxUserDataRecordsPerUser: undefined,
+                maxVirtuosoLoad: undefined,
             },
         ]);
     });
@@ -414,6 +423,7 @@ describe("Test the Profilemodel module", () => {
                 maxWritableTriplesPerUser: undefined,
                 maxUploadTriplesPerUser: undefined,
                 maxUserDataRecordsPerUser: undefined,
+                maxVirtuosoLoad: undefined,
             },
         ]);
     });
@@ -492,6 +502,31 @@ describe("Test the Profilemodel module", () => {
 
     test("getMaxNtExportTriplesForUser is unlimited when no profile of the user sets a cap", async () => {
         const result = await profileModel.getMaxNtExportTriplesForUser({ id: "42", login: "someone", groups: ["all_forbidden"] });
+        expect(result).toBeUndefined();
+    });
+
+    test("getMaxVirtuosoLoadForUser is unlimited for the admin login", async () => {
+        const result = await profileModel.getMaxVirtuosoLoadForUser({ id: "42", login: "admin", groups: [] });
+        expect(result).toBeUndefined();
+    });
+
+    test("getMaxVirtuosoLoadForUser is unlimited for an user holding the admin profile", async () => {
+        const result = await profileModel.getMaxVirtuosoLoadForUser({ id: "42", login: "someone", groups: ["admin"] });
+        expect(result).toBeUndefined();
+    });
+
+    test("getMaxVirtuosoLoadForUser returns the profile's threshold for a single-profile user", async () => {
+        const result = await profileModel.getMaxVirtuosoLoadForUser({ id: "42", login: "someone", groups: ["read_folder_1"] });
+        expect(result).toBe(70);
+    });
+
+    test("getMaxVirtuosoLoadForUser returns the highest threshold across a multi-profile user", async () => {
+        const result = await profileModel.getMaxVirtuosoLoadForUser({ id: "42", login: "someone", groups: ["read_folder_1", "readwrite_folder_1"] });
+        expect(result).toBe(90);
+    });
+
+    test("getMaxVirtuosoLoadForUser is unlimited when no profile of the user sets a threshold", async () => {
+        const result = await profileModel.getMaxVirtuosoLoadForUser({ id: "42", login: "someone", groups: ["all_forbidden"] });
         expect(result).toBeUndefined();
     });
 


### PR DESCRIPTION
Permet de définir un seuil de charge Virtuoso **par profile** en plus du seuil global
(`config.metrics.virtuoso.maxLoad`). Le middleware `restrictVirtuosoLoad`
utilise désormais le seuil le plus permissif applicable à l'utilisateur courant, tout
en conservant la protection globale du serveur.