### PR TITLE
Expose and persist Virtuoso load protection settings in ConfigEditor

### DIFF
--- a/api/v1/paths/config.js
+++ b/api/v1/paths/config.js
@@ -24,6 +24,7 @@ export default function () {
             theme: config.theme,
             sparqlDownloadLimit: config.sparqlDownloadLimit,
             generalQuota: config.generalQuota || {},
+            metrics: { virtuoso: config.metrics?.virtuoso },
         };
 
         res.status(200).json(result);
@@ -34,7 +35,7 @@ export default function () {
         summary: "Return the public server configuration",
         description:
             "Returns the subset of `mainConfig` safe to expose to logged-in users (auth mode, default language, " +
-            "available tools, theme, version, SPARQL download limit, general quota, ...). Credentials of " +
+            "available tools, theme, version, SPARQL download limit, general quota, virtuoso metrics, ...). Credentials of " +
             "`sparql_server` (`user`, `password`) are stripped before returning.",
         operationId: "configGet",
         parameters: [],
@@ -56,6 +57,7 @@ export default function () {
                         theme: { defaultTheme: "default", selector: true },
                         sparqlDownloadLimit: 10000,
                         generalQuota: {},
+                        metrics: { virtuoso: { maxPending: 20, maxLoad: 80 } },
                     },
                 },
             },
@@ -65,10 +67,24 @@ export default function () {
 
     async function PUT(req, res, next) {
         try {
-            const { defaultGroups, tools_available, theme, generalQuota } = req.body;
+            const { defaultGroups, tools_available, theme, generalQuota, metrics } = req.body;
             const initialConfig = await mainConfigModel.getConfig();
-            await mainConfigModel.writeConfig({ ...initialConfig, defaultGroups, tools_available, theme, generalQuota: generalQuota || {} });
-            const newConfig = await mainConfigModel.getConfig({ ...initialConfig, defaultGroups, tools_available, theme, generalQuota: generalQuota || {} });
+            await mainConfigModel.writeConfig({
+                ...initialConfig,
+                defaultGroups,
+                tools_available,
+                theme,
+                generalQuota: generalQuota || {},
+                metrics: { ...initialConfig.metrics, virtuoso: metrics?.virtuoso ?? initialConfig.metrics?.virtuoso },
+            });
+            const newConfig = await mainConfigModel.getConfig({
+                ...initialConfig,
+                defaultGroups,
+                tools_available,
+                theme,
+                generalQuota: generalQuota || {},
+                metrics: { ...initialConfig.metrics, virtuoso: metrics?.virtuoso ?? initialConfig.metrics?.virtuoso },
+            });
             res.status(200).json(newConfig);
         } catch (error) {
             res.status(error.status || 500).json(error);
@@ -80,7 +96,8 @@ export default function () {
         security: [{ restrictAdmin: [] }],
         summary: "Update the writeable subset of the server configuration (admin)",
         description:
-            "Admin-only. Updates `defaultGroups`, `tools_available`, `theme` and `generalQuota` in `mainConfig.json`. " + "All other fields are preserved. Returns the new full configuration.",
+            "Admin-only. Updates `defaultGroups`, `tools_available`, `theme`, `generalQuota` and `metrics.virtuoso` in `mainConfig.json`. " +
+            "All other fields are preserved. Returns the new full configuration.",
         operationId: "configPut",
         parameters: [
             {
@@ -101,12 +118,27 @@ export default function () {
                             example: { defaultTheme: "default", selector: true },
                         },
                         generalQuota: { type: "object", example: {} },
+                        metrics: {
+                            type: "object",
+                            properties: {
+                                virtuoso: {
+                                    type: "object",
+                                    properties: {
+                                        maxPending: { type: "number", example: 20 },
+                                        maxLoad: { type: "number", example: 80 },
+                                    },
+                                    example: { maxPending: 20, maxLoad: 80 },
+                                },
+                            },
+                            example: { virtuoso: { maxPending: 20, maxLoad: 80 } },
+                        },
                     },
                     example: {
                         defaultGroups: ["admin"],
                         tools_available: ["lineage", "KGquery", "MappingModeler", "admin"],
                         theme: { defaultTheme: "default", selector: true },
                         generalQuota: {},
+                        metrics: { virtuoso: { maxPending: 20, maxLoad: 80 } },
                     },
                 },
             },

--- a/mainapp/src/Component/ConfigForm.tsx
+++ b/mainapp/src/Component/ConfigForm.tsx
@@ -98,6 +98,8 @@ const ConfigForm = () => {
     const [defaultGroups, setDefaultGroups] = useState<string[]>([]);
     const [routesInfo, setRoutesInfo] = useState<RouteInfo[]>([]);
     const [generalQuota, setGeneralQuota] = useState<Array<{ route: string; method: string; limit: string }>>([{ route: "", method: "", limit: "" }]);
+    const [virtuosoMaxPending, setVirtuosoMaxPending] = useState<string>("50");
+    const [virtuosoMaxLoad, setVirtuosoMaxLoad] = useState<string>("80");
     const allThemes = useMemo(() => getAvailableThemes(), []);
 
     const notifier = useNotifier();
@@ -117,6 +119,8 @@ const ConfigForm = () => {
                     });
                 }
                 setGeneralQuota(generalQuotaEntries.length > 0 ? generalQuotaEntries : [{ route: "", method: "", limit: "" }]);
+                setVirtuosoMaxPending(String(config.metrics?.virtuoso?.maxPending ?? 50));
+                setVirtuosoMaxLoad(String(config.metrics?.virtuoso?.maxLoad ?? 80));
             })
             .catch((err) => {
                 console.error("Error loading config:", err);
@@ -167,6 +171,12 @@ const ConfigForm = () => {
             },
             sparqlDownloadLimit: 10000,
             generalQuota: generalQuotaObj,
+            metrics: {
+                virtuoso: {
+                    maxPending: Number(virtuosoMaxPending) || 50,
+                    maxLoad: Number(virtuosoMaxLoad) || 80,
+                },
+            },
         };
 
         void updateConfig(configData)
@@ -353,6 +363,41 @@ const ConfigForm = () => {
                                     <Button variant="outlined" onClick={() => setGeneralQuota([...generalQuota, { route: "", method: "", limit: "" }])}>
                                         Add quota
                                     </Button>
+                                </Box>
+                            </FormControl>
+                        </Stack>
+
+                        <Stack direction="column" spacing={{ xs: 2 }} useFlexGap>
+                            <FormControl sx={{ mt: 2 }}>
+                                <Box>
+                                    <Box display="flex" alignItems="center" gap={1}>
+                                        <Typography variant="subtitle1" gutterBottom>
+                                            Virtuoso load protection
+                                        </Typography>
+                                        <HelpTooltip title="Set the in-flight SPARQL request cap (maxPending) and the global load threshold (maxLoad, 0-100) above which protected endpoints reject requests with 429." />
+                                    </Box>
+                                    <Grid container spacing={2}>
+                                        <Grid item xs={6}>
+                                            <TextField
+                                                fullWidth
+                                                type="number"
+                                                label="Max pending SPARQL requests"
+                                                value={virtuosoMaxPending}
+                                                onChange={(e) => setVirtuosoMaxPending(e.target.value)}
+                                                InputProps={{ inputProps: { min: 1 } }}
+                                            />
+                                        </Grid>
+                                        <Grid item xs={6}>
+                                            <TextField
+                                                fullWidth
+                                                type="number"
+                                                label="Max load threshold (%)"
+                                                value={virtuosoMaxLoad}
+                                                onChange={(e) => setVirtuosoMaxLoad(e.target.value)}
+                                                InputProps={{ inputProps: { min: 0, max: 100 } }}
+                                            />
+                                        </Grid>
+                                    </Grid>
                                 </Box>
                             </FormControl>
                         </Stack>

--- a/mainapp/src/Config.ts
+++ b/mainapp/src/Config.ts
@@ -10,6 +10,16 @@ const ConfigSchema = z.object({
     }),
     sparqlDownloadLimit: z.number().positive(),
     generalQuota: z.record(z.record(z.number().positive())).optional().default({}),
+    metrics: z
+        .object({
+            virtuoso: z
+                .object({
+                    maxPending: z.number().positive(),
+                    maxLoad: z.number().positive().max(100),
+                })
+                .optional(),
+        })
+        .optional(),
 });
 
 export type ConfigType = z.infer<typeof ConfigSchema>;

--- a/model/mainConfig.js
+++ b/model/mainConfig.js
@@ -3,6 +3,7 @@ import { Lock } from "async-await-mutex-lock";
 import { mainConfigPath } from "./config.js";
 import { toolModel } from "./tools.js";
 import { quotaModel } from "./quota.js";
+import { configureVirtuosoMetrics } from "../bin/metrics.js";
 
 const lock = new Lock();
 
@@ -31,6 +32,8 @@ class MainConfigModel {
             if (config.generalQuota !== undefined) {
                 quotaModel.clearConfigCache();
             }
+
+            configureVirtuosoMetrics(config.metrics?.virtuoso?.maxPending, config.metrics?.virtuoso?.maxLoad);
         } finally {
             lock.release("MainConfigLock");
         }


### PR DESCRIPTION
Expose and persist metrics.virtuoso.{maxPending,maxLoad} through the
/api/v1/config endpoint and the ConfigEditor Settings form, and refresh
the cached Virtuoso metrics thresholds when the config is written.
